### PR TITLE
fix: re-initialize GIS after logout so login button works again

### DIFF
--- a/src/components/LoginPage.jsx
+++ b/src/components/LoginPage.jsx
@@ -4,15 +4,15 @@ import { useAuth } from '../contexts/AuthContext';
 export default function LoginPage() {
   const { error, setError, clientId, isLoading } = useAuth();
   const buttonRef = useRef(null);
-  const rendered = useRef(false);
 
   useEffect(() => {
-    if (!clientId || rendered.current) return;
+    if (!clientId) return;
 
     const renderButton = () => {
       if (!window.google?.accounts?.id || !buttonRef.current) return;
 
-      rendered.current = true;
+      // Clear previous button content before re-rendering
+      buttonRef.current.innerHTML = '';
       window.google.accounts.id.renderButton(buttonRef.current, {
         type: 'standard',
         theme: 'outline',

--- a/src/contexts/AuthContext.jsx
+++ b/src/contexts/AuthContext.jsx
@@ -61,11 +61,16 @@ export function AuthProvider({ children }) {
     localStorage.removeItem('budget_auth_user');
     // Clear session storage cache as well
     sessionStorage.clear();
-    // Revoke Google session
+    // Re-initialize GIS so the login button works again
     if (window.google?.accounts?.id) {
       window.google.accounts.id.disableAutoSelect();
+      window.google.accounts.id.initialize({
+        client_id: GOOGLE_CLIENT_ID,
+        callback: handleCredentialResponse,
+        auto_select: false,
+      });
     }
-  }, []);
+  }, [handleCredentialResponse]);
 
   // Initialize: check for stored token
   useEffect(() => {


### PR DESCRIPTION
After logout, Google Identity Services needs to be re-initialized with auto_select: false, otherwise the Sign-In button fails with 401: invalid_client on the next login attempt.

https://claude.ai/code/session_01AfbMUJA6oq5KCbyi9K936M