### PR TITLE
Fix form fields overlapping on mobile: stack date/amount and category…

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -279,7 +279,7 @@ const TransactionForm = ({ onSubmit, onClose, kategorie, osoby, isLoading, editD
           </div>
           
           {/* Data i kwota */}
-          <div className="grid grid-cols-2 gap-4">
+          <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
             <div>
               <label className="block text-sm font-medium text-gray-600 mb-2">Data</label>
               <input
@@ -305,7 +305,7 @@ const TransactionForm = ({ onSubmit, onClose, kategorie, osoby, isLoading, editD
           </div>
           
           {/* Kategoria i podkategoria */}
-          <div className="grid grid-cols-2 gap-4">
+          <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
             <div>
               <label className="block text-sm font-medium text-gray-600 mb-2">Kategoria</label>
               <select


### PR DESCRIPTION
… grids

On narrow screens the native date picker overflows its grid column and overlaps the amount input. Switch both two-column grids (date+amount, category+subcategory) to single-column on mobile via grid-cols-1 sm:grid-cols-2.

https://claude.ai/code/session_01DvSszTdQUfeGxpLAuB1e1i