### PR TITLE
Support yearly budgets with monthly overrides (backend + UI)

### DIFF
--- a/components/Budgets.jsx
+++ b/components/Budgets.jsx
@@ -1,4 +1,19 @@
-import React, { useState, useMemo } from 'react';
+import React, { useMemo, useState } from 'react';
+
+const MONTH_NAMES = [
+  'Styczeń',
+  'Luty',
+  'Marzec',
+  'Kwiecień',
+  'Maj',
+  'Czerwiec',
+  'Lipiec',
+  'Sierpień',
+  'Wrzesień',
+  'Październik',
+  'Listopad',
+  'Grudzień',
+];
 
 const formatCurrency = (value) => {
   return new Intl.NumberFormat('pl-PL', {
@@ -9,22 +24,47 @@ const formatCurrency = (value) => {
   }).format(value);
 };
 
-export default function Budgets({ onClose, kategorie = {}, apiUrl, month, year, budgets = [], onSaved, authToken }) {
-  const expenseCats = Object.keys(kategorie['Wydatek'] || {});
+export default function Budgets({
+  onClose,
+  kategorie = {},
+  osoby = [],
+  apiUrl,
+  month,
+  year,
+  budgets = [],
+  onSaved,
+  authToken
+}) {
+  const expenseCats = Object.keys(kategorie.Wydatek || {});
+  const people = useMemo(() => ['Wszyscy', ...(osoby || [])], [osoby]);
 
   const [form, setForm] = useState({
     kategoria: expenseCats[0] || '',
+    osoba: 'Wszyscy',
+    scope: 'monthly',
     limit: '',
     miesiac: month || new Date().getMonth() + 1,
     rok: year || new Date().getFullYear(),
+    notes: '',
   });
 
-  const existingMap = useMemo(() => {
+  const groupedBudgets = useMemo(() => {
     const map = {};
-    (budgets || []).forEach(b => {
-      if (b.kategoria) map[b.kategoria] = b;
+    (budgets || []).forEach((activeBudget) => {
+      const key = [activeBudget.kategoria, activeBudget.osoba || 'Wszyscy'].join('::');
+      if (!map[key]) {
+        map[key] = {
+          kategoria: activeBudget.kategoria,
+          osoba: activeBudget.osoba || 'Wszyscy',
+          yearlyBudget: activeBudget.yearlyBudget || null,
+          monthlyBudget: activeBudget.monthlyBudget || null,
+          activeLimit: Number(activeBudget.limit) || 0,
+          source: activeBudget.source,
+          isOverride: Boolean(activeBudget.isOverride),
+        };
+      }
     });
-    return map;
+    return Object.values(map).sort((a, b) => a.kategoria.localeCompare(b.kategoria, 'pl'));
   }, [budgets]);
 
   const handleSave = async (e) => {
@@ -48,76 +88,212 @@ export default function Budgets({ onClose, kategorie = {}, apiUrl, month, year, 
     }
   };
 
-  const handleSelectExisting = (k) => {
-    const b = existingMap[k];
-    if (b) {
-      setForm({
-        kategoria: b.kategoria,
-        limit: b.limit || '',
-        miesiac: b.miesiac || month,
-        rok: b.rok || year
+  const handleDeleteBudget = async (budget) => {
+    if (!window.confirm('Czy na pewno usunąć ten budżet?')) return;
+
+    try {
+      const res = await fetch(apiUrl, {
+        method: 'POST',
+        body: JSON.stringify({ action: 'deleteBudget', budget, token: authToken })
       });
-    } else {
-      setForm(prev => ({ ...prev, kategoria: k, limit: '' }));
+      const data = await res.json();
+      if (data.success) {
+        if (onSaved) onSaved();
+      } else {
+        alert(data.error || 'Nie udało się usunąć budżetu');
+      }
+    } catch (err) {
+      console.error(err);
+      alert('Błąd połączenia');
     }
   };
 
+  const handleLoadBudgetToForm = (budget) => {
+    setForm({
+      kategoria: budget.kategoria,
+      osoba: budget.osoba || 'Wszyscy',
+      scope: budget.scope,
+      limit: budget.limit || '',
+      miesiac: budget.miesiac || month,
+      rok: budget.rok || year,
+      notes: budget.notes || '',
+    });
+  };
+
+  const yearlyForSelection = useMemo(() => {
+    return (budgets || []).find((b) => (
+      b.kategoria === form.kategoria &&
+      (b.osoba || 'Wszyscy') === (form.osoba || 'Wszyscy') &&
+      b.yearlyBudget
+    ))?.yearlyBudget || null;
+  }, [budgets, form.kategoria, form.osoba]);
+
+  const monthlyForSelection = useMemo(() => {
+    return (budgets || []).find((b) => (
+      b.kategoria === form.kategoria &&
+      (b.osoba || 'Wszyscy') === (form.osoba || 'Wszyscy') &&
+      b.monthlyBudget
+    ))?.monthlyBudget || null;
+  }, [budgets, form.kategoria, form.osoba]);
+
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 backdrop-blur-sm p-4">
-      <div className="w-full max-w-lg rounded-3xl bg-white shadow-2xl">
-        <div className="flex items-center justify-between border-b border-gray-100 px-6 py-4">
+      <div className="w-full max-w-3xl rounded-3xl bg-white shadow-2xl max-h-[95vh] overflow-y-auto">
+        <div className="flex items-center justify-between border-b border-gray-100 px-6 py-4 sticky top-0 bg-white">
           <h2 className="text-xl font-semibold text-gray-800">Budżety</h2>
-          <div className="flex items-center gap-2">
-            <button onClick={onClose} className="rounded-full p-2 text-gray-400 hover:bg-gray-100">Zamknij</button>
-          </div>
+          <button onClick={onClose} className="rounded-full p-2 text-gray-400 hover:bg-gray-100">Zamknij</button>
         </div>
 
-        <div className="p-6">
-          <form onSubmit={handleSave} className="space-y-4">
-            <div>
-              <label className="block text-sm font-medium text-gray-600 mb-2">Kategoria</label>
-              <select value={form.kategoria} onChange={e => setForm(prev => ({ ...prev, kategoria: e.target.value }))} className="w-full rounded-xl border px-4 py-3">
-                {expenseCats.map(k => (
-                  <option key={k} value={k}>{k}</option>
-                ))}
-              </select>
-            </div>
-
-            <div className="grid grid-cols-3 gap-3">
+        <div className="p-6 grid lg:grid-cols-2 gap-6">
+          <section>
+            <h3 className="text-sm font-semibold uppercase tracking-wide text-gray-500 mb-3">Ustaw budżet</h3>
+            <form onSubmit={handleSave} className="space-y-4">
               <div>
-                <label className="block text-sm text-gray-600 mb-2">Limit (PLN)</label>
-                <input type="number" step="0.01" value={form.limit} onChange={e => setForm(prev => ({ ...prev, limit: e.target.value }))} className="w-full rounded-xl border px-4 py-3" />
+                <label className="block text-sm font-medium text-gray-600 mb-2">Kategoria</label>
+                <select value={form.kategoria} onChange={e => setForm(prev => ({ ...prev, kategoria: e.target.value }))} className="w-full rounded-xl border px-4 py-3">
+                  {expenseCats.map(k => (
+                    <option key={k} value={k}>{k}</option>
+                  ))}
+                </select>
               </div>
-              <div>
-                <label className="block text-sm text-gray-600 mb-2">Miesiąc</label>
-                <input type="number" min="1" max="12" value={form.miesiac} onChange={e => setForm(prev => ({ ...prev, miesiac: Number(e.target.value) }))} className="w-full rounded-xl border px-4 py-3" />
-              </div>
-              <div>
-                <label className="block text-sm text-gray-600 mb-2">Rok</label>
-                <input type="number" value={form.rok} onChange={e => setForm(prev => ({ ...prev, rok: Number(e.target.value) }))} className="w-full rounded-xl border px-4 py-3" />
-              </div>
-            </div>
 
-            <div className="flex items-center gap-2">
-              <button type="submit" className="rounded-xl bg-indigo-600 text-white px-4 py-2">Zapisz</button>
-              <button type="button" onClick={() => handleSelectExisting(form.kategoria)} className="text-sm text-gray-500">Wczytaj istniejący</button>
-            </div>
-          </form>
+              <div>
+                <label className="block text-sm font-medium text-gray-600 mb-2">Osoba</label>
+                <select value={form.osoba} onChange={e => setForm(prev => ({ ...prev, osoba: e.target.value }))} className="w-full rounded-xl border px-4 py-3">
+                  {people.map(p => (
+                    <option key={p} value={p}>{p}</option>
+                  ))}
+                </select>
+              </div>
 
-          <div className="mt-6">
-            <h3 className="text-sm font-medium text-gray-700 mb-2">Budżety w tym miesiącu</h3>
-            <div className="space-y-2 max-h-48 overflow-y-auto">
-              {(budgets || []).map(b => (
-                <div key={`${b.kategoria}-${b.miesiac}-${b.rok}`} className="flex items-center justify-between p-3 rounded-xl border border-gray-100">
-                  <div>
-                    <div className="font-medium text-gray-800">{b.kategoria}</div>
-                    <div className="text-xs text-gray-500">{b.miesiac}/{b.rok}</div>
+              <div>
+                <label className="block text-sm font-medium text-gray-600 mb-2">Zakres budżetu</label>
+                <div className="grid grid-cols-2 gap-2">
+                  <button
+                    type="button"
+                    onClick={() => setForm(prev => ({ ...prev, scope: 'monthly' }))}
+                    className={`rounded-xl border px-3 py-2 text-sm ${form.scope === 'monthly' ? 'bg-indigo-600 text-white border-indigo-600' : 'bg-white text-gray-700 border-gray-300'}`}
+                  >
+                    Miesięczny
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => setForm(prev => ({ ...prev, scope: 'yearly' }))}
+                    className={`rounded-xl border px-3 py-2 text-sm ${form.scope === 'yearly' ? 'bg-emerald-600 text-white border-emerald-600' : 'bg-white text-gray-700 border-gray-300'}`}
+                  >
+                    Roczny
+                  </button>
+                </div>
+                <p className="text-xs text-gray-500 mt-2">
+                  {form.scope === 'monthly'
+                    ? `Budżet tylko dla ${MONTH_NAMES[(form.miesiac || 1) - 1]} ${form.rok}.`
+                    : `Budżet domyślny dla całego ${form.rok} roku.`}
+                </p>
+              </div>
+
+              <div className="grid grid-cols-3 gap-3">
+                <div>
+                  <label className="block text-sm text-gray-600 mb-2">Limit (PLN)</label>
+                  <input type="number" step="0.01" value={form.limit} onChange={e => setForm(prev => ({ ...prev, limit: e.target.value }))} className="w-full rounded-xl border px-4 py-3" />
+                </div>
+                <div>
+                  <label className="block text-sm text-gray-600 mb-2">Miesiąc</label>
+                  <input
+                    disabled={form.scope === 'yearly'}
+                    type="number"
+                    min="1"
+                    max="12"
+                    value={form.miesiac}
+                    onChange={e => setForm(prev => ({ ...prev, miesiac: Number(e.target.value) }))}
+                    className="w-full rounded-xl border px-4 py-3 disabled:bg-gray-100"
+                  />
+                </div>
+                <div>
+                  <label className="block text-sm text-gray-600 mb-2">Rok</label>
+                  <input type="number" value={form.rok} onChange={e => setForm(prev => ({ ...prev, rok: Number(e.target.value) }))} className="w-full rounded-xl border px-4 py-3" />
+                </div>
+              </div>
+
+              <div>
+                <label className="block text-sm text-gray-600 mb-2">Notatki (opcjonalnie)</label>
+                <input type="text" value={form.notes} onChange={e => setForm(prev => ({ ...prev, notes: e.target.value }))} className="w-full rounded-xl border px-4 py-3" />
+              </div>
+
+              {form.scope === 'monthly' && yearlyForSelection && (
+                <div className="rounded-xl border border-amber-200 bg-amber-50 p-3 text-sm text-amber-800">
+                  Dla tej kategorii istnieje już budżet roczny ({formatCurrency(yearlyForSelection.limit)}). Ten wpis miesięczny go nadpisze.
+                </div>
+              )}
+
+              {form.scope === 'yearly' && monthlyForSelection && (
+                <div className="rounded-xl border border-sky-200 bg-sky-50 p-3 text-sm text-sky-800">
+                  W tym miesiącu istnieje nadpisanie miesięczne ({formatCurrency(monthlyForSelection.limit)}), które będzie miało wyższy priorytet.
+                </div>
+              )}
+
+              <div className="flex items-center gap-2">
+                <button type="submit" className="rounded-xl bg-indigo-600 text-white px-4 py-2">Zapisz</button>
+              </div>
+            </form>
+          </section>
+
+          <section>
+            <h3 className="text-sm font-semibold uppercase tracking-wide text-gray-500 mb-3">Aktywne budżety ({MONTH_NAMES[(month || 1) - 1]} {year})</h3>
+            <div className="space-y-3 max-h-[60vh] overflow-y-auto pr-1">
+              {groupedBudgets.length === 0 && (
+                <div className="rounded-xl border border-dashed p-4 text-sm text-gray-500">Brak budżetów dla wybranego okresu.</div>
+              )}
+
+              {groupedBudgets.map((group) => (
+                <div key={`${group.kategoria}-${group.osoba}`} className="rounded-xl border border-gray-100 p-4">
+                  <div className="flex items-start justify-between gap-4">
+                    <div>
+                      <div className="font-medium text-gray-800">{group.kategoria} <span className="text-gray-400">({group.osoba})</span></div>
+                      <div className="text-sm mt-1">
+                        Budżet aktywny: <span className="font-semibold">{formatCurrency(group.activeLimit)}</span>
+                        {group.source === 'monthly' && <span className="text-indigo-600"> (miesięczny)</span>}
+                        {group.source === 'yearly' && <span className="text-emerald-600"> (roczny)</span>}
+                      </div>
+                      {group.isOverride && (
+                        <div className="text-xs text-gray-500 mt-1">Nadpisanie: {formatCurrency(group.monthlyBudget.limit)} zamiast rocznego {formatCurrency(group.yearlyBudget.limit)}</div>
+                      )}
+                    </div>
                   </div>
-                  <div className="text-sm font-semibold text-gray-800">{formatCurrency(b.limit)}</div>
+
+                  <div className="mt-3 space-y-2">
+                    {group.yearlyBudget && (
+                      <div className="rounded-lg bg-emerald-50 border border-emerald-100 p-3 flex items-center justify-between gap-3">
+                        <div>
+                          <div className="text-sm font-medium text-emerald-800">Roczny {group.yearlyBudget.rok}: {formatCurrency(group.yearlyBudget.limit)}</div>
+                          {group.yearlyBudget.notes && <div className="text-xs text-emerald-700">{group.yearlyBudget.notes}</div>}
+                        </div>
+                        <div className="flex gap-2">
+                          <button type="button" onClick={() => handleLoadBudgetToForm(group.yearlyBudget)} className="text-xs text-gray-600 hover:text-gray-900">Edytuj</button>
+                          <button type="button" onClick={() => handleDeleteBudget(group.yearlyBudget)} className="text-xs text-rose-600 hover:text-rose-800">Usuń</button>
+                        </div>
+                      </div>
+                    )}
+
+                    {group.monthlyBudget && (
+                      <div className="rounded-lg bg-indigo-50 border border-indigo-100 p-3 flex items-center justify-between gap-3">
+                        <div>
+                          <div className="text-sm font-medium text-indigo-800">
+                            {MONTH_NAMES[(group.monthlyBudget.miesiac || 1) - 1]} {group.monthlyBudget.rok}: {formatCurrency(group.monthlyBudget.limit)}
+                            {group.yearlyBudget ? ' (nadpisuje roczny)' : ''}
+                          </div>
+                          {group.monthlyBudget.notes && <div className="text-xs text-indigo-700">{group.monthlyBudget.notes}</div>}
+                        </div>
+                        <div className="flex gap-2">
+                          <button type="button" onClick={() => handleLoadBudgetToForm(group.monthlyBudget)} className="text-xs text-gray-600 hover:text-gray-900">Edytuj</button>
+                          <button type="button" onClick={() => handleDeleteBudget(group.monthlyBudget)} className="text-xs text-rose-600 hover:text-rose-800">Usuń</button>
+                        </div>
+                      </div>
+                    )}
+                  </div>
                 </div>
               ))}
             </div>
-          </div>
+          </section>
         </div>
       </div>
     </div>

--- a/components/CategoryCharts.jsx
+++ b/components/CategoryCharts.jsx
@@ -319,7 +319,11 @@ export default function CategoryCharts({ transakcje = [], budgets = [], currentP
         {/* ---- Szczegółowa lista kategorii ---- */}
         <div className="mt-6 space-y-2">
           {pieData.map((item, index) => {
-            const budgetForCat = (budgets || []).find(b => b.kategoria === item.name && (!currentPeriod || (Number(b.miesiac) === Number(currentPeriod.month) && Number(b.rok) === Number(currentPeriod.year))));
+            const budgetForCat = (budgets || []).find(b => (
+              b.kategoria === item.name &&
+              (b.osoba === 'Wszyscy' || !b.osoba) &&
+              (!currentPeriod || (Number(b.miesiac) === Number(currentPeriod.month) && Number(b.rok) === Number(currentPeriod.year)))
+            ));
             const limit = budgetForCat ? Number(budgetForCat.limit) : null;
             const percent = limit ? Math.min(item.value / limit, 1) : null;
             let barColor = 'bg-emerald-400';

--- a/google-apps-script/Code.gs
+++ b/google-apps-script/Code.gs
@@ -261,8 +261,10 @@ function initializeSpreadsheet() {
   let budzety = ss.getSheetByName('Budżety');
   if (!budzety) {
     budzety = ss.insertSheet('Budżety');
-    budzety.getRange('A1:D1').setValues([['Kategoria', 'Limit', 'Miesiąc', 'Rok']]);
-    budzety.getRange('A1:D1').setFontWeight('bold');
+    budzety.getRange('A1:H1').setValues([[
+      'Kategoria', 'Osoba', 'Zakres', 'Rok', 'Miesiąc', 'Limit', 'Notatki', 'Utworzono'
+    ]]);
+    budzety.getRange('A1:H1').setFontWeight('bold');
     budzety.setFrozenRows(1);
   }
   
@@ -293,6 +295,12 @@ function doGet(e) {
         break;
       case 'getBudgets':
         result = getBudgets(e.parameter.miesiac, e.parameter.rok);
+        break;
+      case 'getYearlyBudgets':
+        result = getYearlyBudgets(e.parameter.rok);
+        break;
+      case 'getMonthlyBudgets':
+        result = getMonthlyBudgets(e.parameter.miesiac, e.parameter.rok);
         break;
       case 'getKategorie':
         result = getKategorie();
@@ -340,6 +348,12 @@ function doPost(e) {
       case 'getBudgets':
         result = getBudgets(data.miesiac, data.rok);
         break;
+      case 'getYearlyBudgets':
+        result = getYearlyBudgets(data.rok);
+        break;
+      case 'getMonthlyBudgets':
+        result = getMonthlyBudgets(data.miesiac, data.rok);
+        break;
       case 'getKategorie':
         result = getKategorie();
         break;
@@ -376,6 +390,9 @@ function doPost(e) {
         break;
       case 'setBudget':
         result = setBudget(data.budget);
+        break;
+      case 'deleteBudget':
+        result = deleteBudget(data.budget);
         break;
       default:
         result = {error: 'Nieznana akcja'};
@@ -791,35 +808,171 @@ function deleteOsoba(osoba) {
 
 // ============================================
 // BUDŻETY
-// Kolumny w arkuszu 'Budżety': Kategoria | Limit | Miesiąc | Rok
+// Format nowego arkusza "Budżety":
+// Kategoria | Osoba | Zakres | Rok | Miesiąc | Limit | Notatki | Utworzono
+// Kompatybilność wsteczna: stary format (Kategoria | Limit | Miesiąc | Rok)
 // ============================================
+function normalizeBudgetScope(scope) {
+  return scope === 'yearly' ? 'yearly' : 'monthly';
+}
+
+function normalizeBudgetSheet(sheet) {
+  const data = sheet.getDataRange().getValues();
+  if (!data.length) {
+    sheet.getRange('A1:H1').setValues([[
+      'Kategoria', 'Osoba', 'Zakres', 'Rok', 'Miesiąc', 'Limit', 'Notatki', 'Utworzono'
+    ]]);
+    sheet.getRange('A1:H1').setFontWeight('bold');
+    sheet.setFrozenRows(1);
+    return;
+  }
+
+  const header = data[0] || [];
+  const isNewFormat =
+    header[0] === 'Kategoria' &&
+    header[1] === 'Osoba' &&
+    header[2] === 'Zakres' &&
+    header[3] === 'Rok';
+
+  if (isNewFormat) return;
+
+  const migrated = [[
+    'Kategoria', 'Osoba', 'Zakres', 'Rok', 'Miesiąc', 'Limit', 'Notatki', 'Utworzono'
+  ]];
+
+  for (let i = 1; i < data.length; i++) {
+    const row = data[i];
+    if (!row[0]) continue;
+    migrated.push([
+      row[0],
+      'Wszyscy',
+      'monthly',
+      row[3] ? Number(row[3]) : '',
+      row[2] ? Number(row[2]) : '',
+      Number(row[1]) || 0,
+      '',
+      new Date()
+    ]);
+  }
+
+  sheet.clearContents();
+  sheet.getRange(1, 1, migrated.length, 8).setValues(migrated);
+  sheet.getRange('A1:H1').setFontWeight('bold');
+  sheet.setFrozenRows(1);
+}
+
+function parseBudgetRows(data) {
+  const rows = [];
+
+  for (let i = 1; i < data.length; i++) {
+    const row = data[i];
+    if (!row[0]) continue;
+
+    const scope = normalizeBudgetScope((row[2] || '').toString().trim());
+    const year = row[3] ? Number(row[3]) : null;
+    const month = row[4] ? Number(row[4]) : null;
+
+    rows.push({
+      rowIndex: i + 1,
+      kategoria: row[0],
+      osoba: row[1] || 'Wszyscy',
+      scope,
+      rok: year,
+      miesiac: scope === 'monthly' ? month : null,
+      limit: Number(row[5]) || 0,
+      notes: row[6] || ''
+    });
+  }
+
+  return rows;
+}
+
+function getBudgetLookupKey(kategoria, osoba) {
+  return [kategoria, osoba || 'Wszyscy'].join('||');
+}
+
 function getBudgets(miesiac, rok) {
   const ss = SpreadsheetApp.openById(SPREADSHEET_ID);
   const sheet = ss.getSheetByName('Budżety');
   if (!sheet) return [];
 
-  const data = sheet.getDataRange().getValues();
-  const budgets = [];
+  normalizeBudgetSheet(sheet);
+  const rows = parseBudgetRows(sheet.getDataRange().getValues());
 
-  for (let i = 1; i < data.length; i++) {
-    const row = data[i];
-    if (!row[0]) continue;
-    const bMonth = row[2] ? Number(row[2]) : null;
-    const bYear = row[3] ? Number(row[3]) : null;
+  const targetMonth = miesiac ? Number(miesiac) : null;
+  const targetYear = rok ? Number(rok) : null;
 
-    if (miesiac && rok) {
-      if (Number(miesiac) !== bMonth || Number(rok) !== bYear) continue;
+  const yearlyMap = {};
+  const monthlyMap = {};
+
+  rows.forEach((budget) => {
+    if (targetYear && budget.rok !== targetYear) return;
+
+    const key = getBudgetLookupKey(budget.kategoria, budget.osoba);
+
+    if (budget.scope === 'yearly') {
+      yearlyMap[key] = budget;
+      return;
     }
 
-    budgets.push({
-      kategoria: row[0],
-      limit: Number(row[1]) || 0,
-      miesiac: bMonth,
-      rok: bYear
-    });
-  }
+    if (budget.scope === 'monthly') {
+      if (targetMonth && budget.miesiac !== targetMonth) return;
+      monthlyMap[key] = budget;
+    }
+  });
 
-  return budgets;
+  const keys = {};
+  Object.keys(yearlyMap).forEach(k => keys[k] = true);
+  Object.keys(monthlyMap).forEach(k => keys[k] = true);
+
+  return Object.keys(keys).map((key) => {
+    const monthly = monthlyMap[key] || null;
+    const yearly = yearlyMap[key] || null;
+    const active = monthly || yearly;
+
+    return {
+      kategoria: active.kategoria,
+      osoba: active.osoba,
+      limit: active.limit,
+      miesiac: targetMonth,
+      rok: targetYear,
+      scope: active.scope,
+      source: monthly ? 'monthly' : 'yearly',
+      monthlyBudget: monthly,
+      yearlyBudget: yearly,
+      isOverride: Boolean(monthly && yearly)
+    };
+  });
+}
+
+function getYearlyBudgets(rok) {
+  const ss = SpreadsheetApp.openById(SPREADSHEET_ID);
+  const sheet = ss.getSheetByName('Budżety');
+  if (!sheet) return [];
+
+  normalizeBudgetSheet(sheet);
+  const rows = parseBudgetRows(sheet.getDataRange().getValues());
+  const targetYear = rok ? Number(rok) : null;
+
+  return rows.filter((budget) => budget.scope === 'yearly' && (!targetYear || budget.rok === targetYear));
+}
+
+function getMonthlyBudgets(miesiac, rok) {
+  const ss = SpreadsheetApp.openById(SPREADSHEET_ID);
+  const sheet = ss.getSheetByName('Budżety');
+  if (!sheet) return [];
+
+  normalizeBudgetSheet(sheet);
+  const rows = parseBudgetRows(sheet.getDataRange().getValues());
+  const targetMonth = miesiac ? Number(miesiac) : null;
+  const targetYear = rok ? Number(rok) : null;
+
+  return rows.filter((budget) => {
+    if (budget.scope !== 'monthly') return false;
+    if (targetYear && budget.rok !== targetYear) return false;
+    if (targetMonth && budget.miesiac !== targetMonth) return false;
+    return true;
+  });
 }
 
 function setBudget(budget) {
@@ -829,25 +982,93 @@ function setBudget(budget) {
   const sheet = ss.getSheetByName('Budżety');
   if (!sheet) return { success: false, error: 'Arkusz Budżety nie istnieje' };
 
-  const data = sheet.getDataRange().getValues();
-  const targetMonth = budget.miesiac ? Number(budget.miesiac) : null;
-  const targetYear = budget.rok ? Number(budget.rok) : null;
-  const limit = Number(budget.limit) || 0;
+  normalizeBudgetSheet(sheet);
 
-  // Szukaj istniejącego wpisu (kategoria + miesiąc + rok)
+  const data = sheet.getDataRange().getValues();
+  const scope = normalizeBudgetScope((budget.scope || '').toString().trim());
+  const targetYear = budget.rok ? Number(budget.rok) : null;
+  const targetMonth = scope === 'monthly' && budget.miesiac ? Number(budget.miesiac) : null;
+  const limit = Number(budget.limit) || 0;
+  const osoba = budget.osoba || 'Wszyscy';
+  const notes = budget.notes || '';
+
+  if (!targetYear) {
+    return { success: false, error: 'Rok jest wymagany' };
+  }
+  if (scope === 'monthly' && (!targetMonth || targetMonth < 1 || targetMonth > 12)) {
+    return { success: false, error: 'Dla budżetu miesięcznego wymagany jest miesiąc 1-12' };
+  }
+
   for (let i = 1; i < data.length; i++) {
     const row = data[i];
     const rowCat = row[0];
-    const rowMonth = row[2] ? Number(row[2]) : null;
+    const rowOsoba = row[1] || 'Wszyscy';
+    const rowScope = normalizeBudgetScope((row[2] || '').toString().trim());
     const rowYear = row[3] ? Number(row[3]) : null;
+    const rowMonth = row[4] ? Number(row[4]) : null;
 
-    if (rowCat === budget.kategoria && rowMonth === targetMonth && rowYear === targetYear) {
-      sheet.getRange(i + 1, 2).setValue(limit);
+    const matches =
+      rowCat === budget.kategoria &&
+      rowOsoba === osoba &&
+      rowScope === scope &&
+      rowYear === targetYear &&
+      (scope === 'yearly' || rowMonth === targetMonth);
+
+    if (matches) {
+      sheet.getRange(i + 1, 6).setValue(limit);
+      sheet.getRange(i + 1, 7).setValue(notes);
       return { success: true, message: 'Zaktualizowano budżet' };
     }
   }
 
-  // Jeśli nie znaleziono — dopisz nowy wiersz
-  sheet.appendRow([budget.kategoria, limit, targetMonth || '', targetYear || '']);
+  sheet.appendRow([
+    budget.kategoria,
+    osoba,
+    scope,
+    targetYear,
+    scope === 'monthly' ? targetMonth : '',
+    limit,
+    notes,
+    new Date()
+  ]);
+
   return { success: true, message: 'Dodano budżet' };
+}
+
+function deleteBudget(budget) {
+  if (!budget || !budget.kategoria) return { success: false, error: 'Brak danych budżetu do usunięcia' };
+
+  const ss = SpreadsheetApp.openById(SPREADSHEET_ID);
+  const sheet = ss.getSheetByName('Budżety');
+  if (!sheet) return { success: false, error: 'Arkusz Budżety nie istnieje' };
+
+  normalizeBudgetSheet(sheet);
+
+  const scope = normalizeBudgetScope((budget.scope || '').toString().trim());
+  const targetYear = budget.rok ? Number(budget.rok) : null;
+  const targetMonth = scope === 'monthly' && budget.miesiac ? Number(budget.miesiac) : null;
+  const osoba = budget.osoba || 'Wszyscy';
+
+  const data = sheet.getDataRange().getValues();
+  for (let i = 1; i < data.length; i++) {
+    const row = data[i];
+    const rowScope = normalizeBudgetScope((row[2] || '').toString().trim());
+    const rowMonth = row[4] ? Number(row[4]) : null;
+    const rowYear = row[3] ? Number(row[3]) : null;
+    const rowOsoba = row[1] || 'Wszyscy';
+
+    const matches =
+      row[0] === budget.kategoria &&
+      rowOsoba === osoba &&
+      rowScope === scope &&
+      rowYear === targetYear &&
+      (scope === 'yearly' || rowMonth === targetMonth);
+
+    if (matches) {
+      sheet.deleteRow(i + 1);
+      return { success: true, message: 'Usunięto budżet' };
+    }
+  }
+
+  return { success: false, error: 'Nie znaleziono budżetu do usunięcia' };
 }

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1592,6 +1592,7 @@ export default function BudgetApp() {
         <Budgets
           onClose={() => setShowBudgets(false)}
           kategorie={kategorie}
+          osoby={osoby}
           apiUrl={API_URL}
           month={currentPeriod.month}
           year={currentPeriod.year}
@@ -1617,6 +1618,7 @@ export default function BudgetApp() {
         <CSVImport
           onClose={() => setShowCSVImport(false)}
           kategorie={kategorie}
+          osoby={osoby}
           apiUrl={API_URL}
           authToken={token}
           onSaved={() => {


### PR DESCRIPTION
### Motivation
- Provide a way to define a single yearly budget applied automatically to all months while allowing specific months to override it, reducing repetitive per-month input.
- Allow budgets to target a specific person (or `Wszyscy`) and carry optional notes to support household/sharing scenarios.
- Keep backward compatibility with the existing 4-column `Budżety` sheet so existing data is migrated automatically.

### Description
- Extended the Google Apps Script budget model in `google-apps-script/Code.gs` to a new 8-column format (`Kategoria | Osoba | Zakres | Rok | Miesiąc | Limit | Notatki | Utworzono`) and added `normalizeBudgetSheet`/`parseBudgetRows` migration helpers. 
- Implemented budget resolution in `getBudgets` so that `monthly` budgets override `yearly` for the requested month/year and the response includes metadata fields `source`, `isOverride`, `monthlyBudget`, and `yearlyBudget`, and added new endpoints `getYearlyBudgets`, `getMonthlyBudgets`, and `deleteBudget`.
- Reworked the Budgets UI in `components/Budgets.jsx` to support `monthly`/`yearly` toggle, `osoba` selection, `notes`, warnings about overrides, grouped listing of active budgets, and edit/delete actions; passed `osoby` into the modal from `src/App.jsx` and adjusted `components/CategoryCharts.jsx` to use the shared (`Wszyscy`) budget when rendering category limits.
- Added server-side validations for scope/month/year and preserved compatibility by migrating old-format rows into the new schema as monthly budgets for `Wszyscy`.

### Testing
- Ran the production build with `npm run build`, which completed successfully without fatal errors.
- Started the dev server and performed a Playwright smoke check that loaded the app page and saved a screenshot artifact (page reachable and screenshot produced at the run artifact), confirming the UI loads after changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698b6655dd0c83308b48b46182f742d8)