### PR TITLE
fix: resolve overlapping text on transaction save button

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -377,10 +377,15 @@ const TransactionForm = ({ onSubmit, onClose, kategorie, osoby, isLoading, editD
           <button
             type="submit"
             disabled={isLoading || !formData.kwota || !formData.kategoria}
-            className="w-full rounded-xl bg-gradient-to-r from-indigo-500 to-purple-600 py-4 font-semibold text-white shadow-lg shadow-indigo-200 hover:shadow-xl hover:shadow-indigo-300 transition-all disabled:opacity-50 disabled:cursor-not-allowed flex items-center justify-center gap-2"
+            className="w-full rounded-xl bg-gradient-to-r from-indigo-500 to-purple-600 py-4 font-semibold text-white shadow-lg shadow-indigo-200 hover:shadow-xl hover:shadow-indigo-300 transition-colors disabled:opacity-50 disabled:cursor-not-allowed flex items-center justify-center gap-2"
           >
-            {isLoading ? <Icons.Loader /> : isEditMode ? <Icons.Edit /> : <Icons.Plus />}
-            {isLoading ? 'Zapisywanie...' : isEditMode ? 'Zapisz zmiany' : 'Dodaj transakcję'}
+            {isLoading ? (
+              <><Icons.Loader /> Zapisywanie...</>
+            ) : isEditMode ? (
+              <><Icons.Edit /> Zapisz zmiany</>
+            ) : (
+              <><Icons.Plus /> Dodaj transakcję</>
+            )}
           </button>
         </form>
       </div>


### PR DESCRIPTION
Replace two separate ternary expressions with a single conditional block using React fragments so the entire button content (icon + text) swaps atomically. Change transition-all to transition-colors to prevent unexpected CSS transitions on layout properties during state changes.

https://claude.ai/code/session_01CSyFGG6GLrGqjccEtKkoBb