### PR TITLE
feat: add recurring budget support (yearly/monthly with hierarchy)

### DIFF
--- a/components/Budgets.jsx
+++ b/components/Budgets.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useMemo } from 'react';
+import React, { useState, useMemo, useEffect } from 'react';
 
 const formatCurrency = (value) => {
   return new Intl.NumberFormat('pl-PL', {
@@ -9,7 +9,12 @@ const formatCurrency = (value) => {
   }).format(value);
 };
 
-export default function Budgets({ onClose, kategorie = {}, apiUrl, month, year, budgets = [], onSaved, authToken }) {
+const MONTH_NAMES = [
+  '', 'Styczeń', 'Luty', 'Marzec', 'Kwiecień', 'Maj', 'Czerwiec',
+  'Lipiec', 'Sierpień', 'Wrzesień', 'Październik', 'Listopad', 'Grudzień'
+];
+
+export default function Budgets({ onClose, kategorie = {}, apiUrl, month, year, budgets = [], onSaved, authToken, osoby = [] }) {
   const expenseCats = Object.keys(kategorie['Wydatek'] || {});
 
   const [form, setForm] = useState({
@@ -17,30 +22,140 @@ export default function Budgets({ onClose, kategorie = {}, apiUrl, month, year, 
     limit: '',
     miesiac: month || new Date().getMonth() + 1,
     rok: year || new Date().getFullYear(),
+    osoba: '',
+    zakres: 'monthly',
+    notatki: '',
   });
 
-  const existingMap = useMemo(() => {
-    const map = {};
-    (budgets || []).forEach(b => {
-      if (b.kategoria) map[b.kategoria] = b;
+  const [allBudgets, setAllBudgets] = useState([]);
+  const [isLoadingAll, setIsLoadingAll] = useState(false);
+  const [isSaving, setIsSaving] = useState(false);
+  const [confirmOverride, setConfirmOverride] = useState(null);
+
+  // Pobierz wszystkie budżety dla roku (do widoku zarządzania)
+  const fetchAllBudgets = async () => {
+    setIsLoadingAll(true);
+    try {
+      const res = await fetch(apiUrl, {
+        method: 'POST',
+        body: JSON.stringify({ action: 'getAllBudgetsForYear', rok: form.rok, token: authToken })
+      });
+      const data = await res.json();
+      if (!data.error) {
+        setAllBudgets(Array.isArray(data) ? data : []);
+      }
+    } catch (err) {
+      console.warn('Nie udało się pobrać budżetów rocznych', err);
+    } finally {
+      setIsLoadingAll(false);
+    }
+  };
+
+  useEffect(() => {
+    fetchAllBudgets();
+  }, [form.rok]);
+
+  // Grupowanie budżetów do widoku drzewa: { kategoria+osoba → { yearly, monthly: []} }
+  const budgetTree = useMemo(() => {
+    const tree = {};
+    allBudgets.forEach(b => {
+      const key = b.kategoria + '|' + (b.osoba || '');
+      if (!tree[key]) {
+        tree[key] = { kategoria: b.kategoria, osoba: b.osoba || '', yearly: null, monthly: [] };
+      }
+      if (b.zakres === 'yearly') {
+        tree[key].yearly = b;
+      } else {
+        tree[key].monthly.push(b);
+      }
     });
-    return map;
-  }, [budgets]);
+
+    // Sortuj monthly po miesiącu
+    Object.values(tree).forEach(entry => {
+      entry.monthly.sort((a, b) => (a.miesiac || 0) - (b.miesiac || 0));
+    });
+
+    return tree;
+  }, [allBudgets]);
+
+  // Sprawdź czy istnieje budżet roczny dla wybranej kategorii/osoby
+  const existingYearly = useMemo(() => {
+    return allBudgets.find(b =>
+      b.kategoria === form.kategoria &&
+      (b.osoba || '') === form.osoba &&
+      b.zakres === 'yearly' &&
+      b.rok === Number(form.rok)
+    );
+  }, [allBudgets, form.kategoria, form.osoba, form.rok]);
 
   const handleSave = async (e) => {
-    e.preventDefault();
+    if (e) e.preventDefault();
     if (!form.kategoria) return;
+
+    // Ostrzeżenie: tworzenie budżetu miesięcznego gdy istnieje roczny
+    if (form.zakres === 'monthly' && existingYearly && !confirmOverride) {
+      setConfirmOverride({
+        message: `Kategoria "${form.kategoria}" ma budżet roczny ${formatCurrency(existingYearly.limit)}. Budżet miesięczny nadpisze go dla ${MONTH_NAMES[form.miesiac]} ${form.rok}.`,
+        onConfirm: () => {
+          setConfirmOverride(null);
+          doSave();
+        }
+      });
+      return;
+    }
+
+    await doSave();
+  };
+
+  const doSave = async () => {
+    setIsSaving(true);
+    try {
+      const budgetData = {
+        kategoria: form.kategoria,
+        limit: form.limit,
+        rok: Number(form.rok),
+        osoba: form.osoba,
+        zakres: form.zakres,
+        notatki: form.notatki,
+      };
+      if (form.zakres === 'monthly') {
+        budgetData.miesiac = Number(form.miesiac);
+      }
+
+      const res = await fetch(apiUrl, {
+        method: 'POST',
+        body: JSON.stringify({ action: 'setBudget', budget: budgetData, token: authToken })
+      });
+      const data = await res.json();
+      if (data.success) {
+        await fetchAllBudgets();
+        if (onSaved) onSaved();
+        setForm(prev => ({ ...prev, limit: '', notatki: '' }));
+      } else {
+        alert(data.error || 'Błąd zapisu budżetu');
+      }
+    } catch (err) {
+      console.error(err);
+      alert('Błąd połączenia');
+    } finally {
+      setIsSaving(false);
+    }
+  };
+
+  const handleDelete = async (budget) => {
+    if (!window.confirm(`Czy na pewno chcesz usunąć budżet ${budget.zakres === 'yearly' ? 'roczny' : 'miesięczny'} dla "${budget.kategoria}"?`)) return;
 
     try {
       const res = await fetch(apiUrl, {
         method: 'POST',
-        body: JSON.stringify({ action: 'setBudget', budget: form, token: authToken })
+        body: JSON.stringify({ action: 'deleteBudget', budget, token: authToken })
       });
       const data = await res.json();
       if (data.success) {
+        await fetchAllBudgets();
         if (onSaved) onSaved();
       } else {
-        alert(data.error || 'Błąd zapisu budżetu');
+        alert(data.error || 'Błąd usuwania budżetu');
       }
     } catch (err) {
       console.error(err);
@@ -48,78 +163,321 @@ export default function Budgets({ onClose, kategorie = {}, apiUrl, month, year, 
     }
   };
 
-  const handleSelectExisting = (k) => {
-    const b = existingMap[k];
-    if (b) {
-      setForm({
-        kategoria: b.kategoria,
-        limit: b.limit || '',
-        miesiac: b.miesiac || month,
-        rok: b.rok || year
-      });
-    } else {
-      setForm(prev => ({ ...prev, kategoria: k, limit: '' }));
-    }
+  const handleLoadExisting = (budget) => {
+    setForm({
+      kategoria: budget.kategoria,
+      limit: budget.limit || '',
+      miesiac: budget.miesiac || month,
+      rok: budget.rok || year,
+      osoba: budget.osoba || '',
+      zakres: budget.zakres || 'monthly',
+      notatki: budget.notatki || '',
+    });
   };
 
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 backdrop-blur-sm p-4">
-      <div className="w-full max-w-lg rounded-3xl bg-white shadow-2xl">
-        <div className="flex items-center justify-between border-b border-gray-100 px-6 py-4">
+      <div className="w-full max-w-xl max-h-[90vh] rounded-3xl bg-white shadow-2xl flex flex-col">
+        {/* Header */}
+        <div className="flex items-center justify-between border-b border-gray-100 px-6 py-4 shrink-0">
           <h2 className="text-xl font-semibold text-gray-800">Budżety</h2>
-          <div className="flex items-center gap-2">
-            <button onClick={onClose} className="rounded-full p-2 text-gray-400 hover:bg-gray-100">Zamknij</button>
-          </div>
+          <button onClick={onClose} className="rounded-full p-2 text-gray-400 hover:bg-gray-100 transition-colors">
+            <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><line x1="18" y1="6" x2="6" y2="18"/><line x1="6" y1="6" x2="18" y2="18"/></svg>
+          </button>
         </div>
 
-        <div className="p-6">
+        <div className="flex-1 overflow-y-auto p-6 space-y-6">
+          {/* Formularz */}
           <form onSubmit={handleSave} className="space-y-4">
+            {/* Zakres - toggle */}
+            <div>
+              <label className="block text-sm font-medium text-gray-600 mb-2">Zakres budżetu</label>
+              <div className="flex gap-2">
+                <button
+                  type="button"
+                  onClick={() => setForm(prev => ({ ...prev, zakres: 'monthly' }))}
+                  className={`flex-1 rounded-xl py-2.5 px-3 text-sm font-medium transition-all ${
+                    form.zakres === 'monthly'
+                      ? 'bg-indigo-500 text-white shadow-lg shadow-indigo-200'
+                      : 'bg-gray-100 text-gray-600 hover:bg-gray-200'
+                  }`}
+                >
+                  <div className="flex items-center justify-center gap-1.5">
+                    <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><rect x="3" y="4" width="18" height="18" rx="2" ry="2"/><line x1="16" y1="2" x2="16" y2="6"/><line x1="8" y1="2" x2="8" y2="6"/><line x1="3" y1="10" x2="21" y2="10"/></svg>
+                    Miesięczny
+                  </div>
+                </button>
+                <button
+                  type="button"
+                  onClick={() => setForm(prev => ({ ...prev, zakres: 'yearly' }))}
+                  className={`flex-1 rounded-xl py-2.5 px-3 text-sm font-medium transition-all ${
+                    form.zakres === 'yearly'
+                      ? 'bg-purple-500 text-white shadow-lg shadow-purple-200'
+                      : 'bg-gray-100 text-gray-600 hover:bg-gray-200'
+                  }`}
+                >
+                  <div className="flex items-center justify-center gap-1.5">
+                    <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><circle cx="12" cy="12" r="10"/><polyline points="12 6 12 12 16 14"/></svg>
+                    Roczny
+                  </div>
+                </button>
+              </div>
+              <p className="text-xs text-gray-400 mt-1.5">
+                {form.zakres === 'yearly'
+                  ? 'Budżet stosowany automatycznie do wszystkich miesięcy roku'
+                  : 'Budżet tylko dla wybranego miesiąca (nadpisuje roczny)'}
+              </p>
+            </div>
+
+            {/* Kategoria */}
             <div>
               <label className="block text-sm font-medium text-gray-600 mb-2">Kategoria</label>
-              <select value={form.kategoria} onChange={e => setForm(prev => ({ ...prev, kategoria: e.target.value }))} className="w-full rounded-xl border px-4 py-3">
+              <select
+                value={form.kategoria}
+                onChange={e => setForm(prev => ({ ...prev, kategoria: e.target.value }))}
+                className="w-full rounded-xl border border-gray-200 px-4 py-3 focus:border-indigo-500 focus:ring-2 focus:ring-indigo-200 outline-none transition-all bg-white"
+              >
                 {expenseCats.map(k => (
                   <option key={k} value={k}>{k}</option>
                 ))}
               </select>
             </div>
 
-            <div className="grid grid-cols-3 gap-3">
-              <div>
+            {/* Osoba */}
+            <div>
+              <label className="block text-sm font-medium text-gray-600 mb-2">Osoba</label>
+              <div className="flex gap-2 flex-wrap">
+                <button
+                  type="button"
+                  onClick={() => setForm(prev => ({ ...prev, osoba: '' }))}
+                  className={`rounded-xl py-2 px-3 text-sm font-medium transition-all ${
+                    form.osoba === ''
+                      ? 'bg-indigo-500 text-white shadow-sm'
+                      : 'bg-gray-100 text-gray-600 hover:bg-gray-200'
+                  }`}
+                >
+                  Wszyscy
+                </button>
+                {osoby.map(o => (
+                  <button
+                    key={o}
+                    type="button"
+                    onClick={() => setForm(prev => ({ ...prev, osoba: o }))}
+                    className={`rounded-xl py-2 px-3 text-sm font-medium transition-all ${
+                      form.osoba === o
+                        ? 'bg-indigo-500 text-white shadow-sm'
+                        : 'bg-gray-100 text-gray-600 hover:bg-gray-200'
+                    }`}
+                  >
+                    {o}
+                  </button>
+                ))}
+              </div>
+            </div>
+
+            {/* Limit + Okres */}
+            <div className={`grid gap-3 ${form.zakres === 'monthly' ? 'grid-cols-4' : 'grid-cols-2'}`}>
+              <div className={form.zakres === 'monthly' ? 'col-span-2' : ''}>
                 <label className="block text-sm text-gray-600 mb-2">Limit (PLN)</label>
-                <input type="number" step="0.01" value={form.limit} onChange={e => setForm(prev => ({ ...prev, limit: e.target.value }))} className="w-full rounded-xl border px-4 py-3" />
+                <input
+                  type="number"
+                  step="0.01"
+                  value={form.limit}
+                  onChange={e => setForm(prev => ({ ...prev, limit: e.target.value }))}
+                  className="w-full rounded-xl border border-gray-200 px-4 py-3 focus:border-indigo-500 focus:ring-2 focus:ring-indigo-200 outline-none transition-all"
+                  placeholder="0"
+                  required
+                />
               </div>
-              <div>
-                <label className="block text-sm text-gray-600 mb-2">Miesiąc</label>
-                <input type="number" min="1" max="12" value={form.miesiac} onChange={e => setForm(prev => ({ ...prev, miesiac: Number(e.target.value) }))} className="w-full rounded-xl border px-4 py-3" />
-              </div>
+              {form.zakres === 'monthly' && (
+                <div>
+                  <label className="block text-sm text-gray-600 mb-2">Miesiąc</label>
+                  <select
+                    value={form.miesiac}
+                    onChange={e => setForm(prev => ({ ...prev, miesiac: Number(e.target.value) }))}
+                    className="w-full rounded-xl border border-gray-200 px-3 py-3 focus:border-indigo-500 focus:ring-2 focus:ring-indigo-200 outline-none transition-all bg-white"
+                  >
+                    {Array.from({ length: 12 }, (_, i) => i + 1).map(m => (
+                      <option key={m} value={m}>{MONTH_NAMES[m]}</option>
+                    ))}
+                  </select>
+                </div>
+              )}
               <div>
                 <label className="block text-sm text-gray-600 mb-2">Rok</label>
-                <input type="number" value={form.rok} onChange={e => setForm(prev => ({ ...prev, rok: Number(e.target.value) }))} className="w-full rounded-xl border px-4 py-3" />
+                <input
+                  type="number"
+                  value={form.rok}
+                  onChange={e => setForm(prev => ({ ...prev, rok: Number(e.target.value) }))}
+                  className="w-full rounded-xl border border-gray-200 px-4 py-3 focus:border-indigo-500 focus:ring-2 focus:ring-indigo-200 outline-none transition-all"
+                />
               </div>
             </div>
 
-            <div className="flex items-center gap-2">
-              <button type="submit" className="rounded-xl bg-indigo-600 text-white px-4 py-2">Zapisz</button>
-              <button type="button" onClick={() => handleSelectExisting(form.kategoria)} className="text-sm text-gray-500">Wczytaj istniejący</button>
+            {/* Notatki */}
+            <div>
+              <label className="block text-sm text-gray-600 mb-2">Notatki (opcjonalnie)</label>
+              <input
+                type="text"
+                value={form.notatki}
+                onChange={e => setForm(prev => ({ ...prev, notatki: e.target.value }))}
+                className="w-full rounded-xl border border-gray-200 px-4 py-3 focus:border-indigo-500 focus:ring-2 focus:ring-indigo-200 outline-none transition-all"
+                placeholder="np. Święta, wakacje..."
+              />
             </div>
+
+            {/* Info o nadpisaniu rocznego */}
+            {form.zakres === 'monthly' && existingYearly && (
+              <div className="rounded-xl bg-amber-50 border border-amber-200 px-4 py-3 text-sm text-amber-700 flex items-start gap-2">
+                <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="mt-0.5 shrink-0"><path d="M10.29 3.86L1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.71 3.86a2 2 0 0 0-3.42 0z"/><line x1="12" y1="9" x2="12" y2="13"/><line x1="12" y1="17" x2="12.01" y2="17"/></svg>
+                <span>Istnieje budżet roczny: {formatCurrency(existingYearly.limit)}/mies. Budżet miesięczny nadpisze go dla wybranego miesiąca.</span>
+              </div>
+            )}
+
+            <button
+              type="submit"
+              disabled={isSaving || !form.limit}
+              className="w-full rounded-xl bg-gradient-to-r from-indigo-500 to-purple-600 py-3 text-sm font-semibold text-white shadow-lg shadow-indigo-200 hover:shadow-xl transition-all disabled:opacity-50 disabled:cursor-not-allowed flex items-center justify-center gap-2"
+            >
+              {isSaving ? (
+                <><svg className="animate-spin" xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2"><path d="M21 12a9 9 0 1 1-6.219-8.56"/></svg> Zapisywanie...</>
+              ) : (
+                'Zapisz budżet'
+              )}
+            </button>
           </form>
 
-          <div className="mt-6">
-            <h3 className="text-sm font-medium text-gray-700 mb-2">Budżety w tym miesiącu</h3>
-            <div className="space-y-2 max-h-48 overflow-y-auto">
-              {(budgets || []).map(b => (
-                <div key={`${b.kategoria}-${b.miesiac}-${b.rok}`} className="flex items-center justify-between p-3 rounded-xl border border-gray-100">
-                  <div>
-                    <div className="font-medium text-gray-800">{b.kategoria}</div>
-                    <div className="text-xs text-gray-500">{b.miesiac}/{b.rok}</div>
+          {/* Lista budżetów - widok drzewa */}
+          <div>
+            <h3 className="text-sm font-semibold text-gray-700 mb-3 flex items-center gap-2">
+              Budżety na {form.rok}
+              {isLoadingAll && <svg className="animate-spin" xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2"><path d="M21 12a9 9 0 1 1-6.219-8.56"/></svg>}
+            </h3>
+
+            {Object.keys(budgetTree).length === 0 ? (
+              <p className="text-sm text-gray-400 py-4 text-center">Brak budżetów na ten rok</p>
+            ) : (
+              <div className="space-y-3">
+                {Object.entries(budgetTree).map(([key, entry]) => (
+                  <div key={key} className="rounded-xl border border-gray-100 overflow-hidden">
+                    {/* Header kategorii */}
+                    <div className="bg-gray-50/50 px-4 py-2.5 flex items-center justify-between">
+                      <div>
+                        <span className="font-medium text-gray-800">{entry.kategoria}</span>
+                        {entry.osoba && (
+                          <span className="text-xs text-gray-500 ml-2">({entry.osoba})</span>
+                        )}
+                        {!entry.osoba && (
+                          <span className="text-xs text-gray-400 ml-2">(Wszyscy)</span>
+                        )}
+                      </div>
+                    </div>
+
+                    <div className="divide-y divide-gray-50">
+                      {/* Budżet roczny */}
+                      {entry.yearly && (
+                        <div className="flex items-center gap-3 px-4 py-2.5 hover:bg-gray-50 transition-colors">
+                          <div className="flex items-center gap-1.5 shrink-0">
+                            <span className="w-2 h-2 rounded-full bg-purple-400"></span>
+                            <span className="text-xs font-medium text-purple-600 uppercase">Roczny</span>
+                          </div>
+                          <div className="flex-1 min-w-0">
+                            <span className="text-sm font-semibold text-gray-800">{formatCurrency(entry.yearly.limit)}</span>
+                            <span className="text-xs text-gray-400 ml-1">/mies.</span>
+                            {entry.yearly.notatki && (
+                              <span className="text-xs text-gray-400 ml-2 truncate">— {entry.yearly.notatki}</span>
+                            )}
+                          </div>
+                          <div className="flex items-center gap-1 shrink-0">
+                            <button
+                              onClick={() => handleLoadExisting(entry.yearly)}
+                              className="rounded-lg p-1.5 text-gray-400 hover:bg-indigo-100 hover:text-indigo-600 transition-all"
+                              title="Edytuj"
+                            >
+                              <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><path d="M17 3a2.85 2.83 0 1 1 4 4L7.5 20.5 2 22l1.5-5.5Z"/></svg>
+                            </button>
+                            <button
+                              onClick={() => handleDelete(entry.yearly)}
+                              className="rounded-lg p-1.5 text-gray-400 hover:bg-rose-100 hover:text-rose-600 transition-all"
+                              title="Usuń"
+                            >
+                              <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><polyline points="3 6 5 6 21 6"/><path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6m3 0V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2"/></svg>
+                            </button>
+                          </div>
+                        </div>
+                      )}
+
+                      {/* Budżety miesięczne */}
+                      {entry.monthly.map(mb => (
+                        <div key={`${mb.miesiac}-${mb.rok}`} className="flex items-center gap-3 px-4 py-2.5 hover:bg-gray-50 transition-colors">
+                          <div className="flex items-center gap-1.5 shrink-0">
+                            <span className="w-2 h-2 rounded-full bg-indigo-400"></span>
+                            <span className="text-xs font-medium text-indigo-600">{MONTH_NAMES[mb.miesiac]}</span>
+                          </div>
+                          <div className="flex-1 min-w-0">
+                            <span className="text-sm font-semibold text-gray-800">{formatCurrency(mb.limit)}</span>
+                            {entry.yearly && (
+                              <span className="text-xs text-amber-600 ml-2">(nadpisuje roczny)</span>
+                            )}
+                            {mb.notatki && (
+                              <span className="text-xs text-gray-400 ml-2 truncate">— {mb.notatki}</span>
+                            )}
+                          </div>
+                          <div className="flex items-center gap-1 shrink-0">
+                            <button
+                              onClick={() => handleLoadExisting(mb)}
+                              className="rounded-lg p-1.5 text-gray-400 hover:bg-indigo-100 hover:text-indigo-600 transition-all"
+                              title="Edytuj"
+                            >
+                              <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><path d="M17 3a2.85 2.83 0 1 1 4 4L7.5 20.5 2 22l1.5-5.5Z"/></svg>
+                            </button>
+                            <button
+                              onClick={() => handleDelete(mb)}
+                              className="rounded-lg p-1.5 text-gray-400 hover:bg-rose-100 hover:text-rose-600 transition-all"
+                              title="Usuń"
+                            >
+                              <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><polyline points="3 6 5 6 21 6"/><path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6m3 0V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2"/></svg>
+                            </button>
+                          </div>
+                        </div>
+                      ))}
+                    </div>
                   </div>
-                  <div className="text-sm font-semibold text-gray-800">{formatCurrency(b.limit)}</div>
-                </div>
-              ))}
-            </div>
+                ))}
+              </div>
+            )}
           </div>
         </div>
       </div>
+
+      {/* Dialog potwierdzenia nadpisania */}
+      {confirmOverride && (
+        <div className="fixed inset-0 z-[60] flex items-center justify-center bg-black/60 backdrop-blur-sm p-4">
+          <div className="w-full max-w-sm rounded-2xl bg-white shadow-2xl p-6 space-y-4">
+            <div className="flex items-center gap-3">
+              <div className="rounded-lg bg-amber-100 p-2 text-amber-600">
+                <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><path d="M10.29 3.86L1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.71 3.86a2 2 0 0 0-3.42 0z"/><line x1="12" y1="9" x2="12" y2="13"/><line x1="12" y1="17" x2="12.01" y2="17"/></svg>
+              </div>
+              <h3 className="text-lg font-semibold text-gray-800">Nadpisanie budżetu rocznego</h3>
+            </div>
+            <p className="text-sm text-gray-600 leading-relaxed">{confirmOverride.message}</p>
+            <div className="flex gap-3 pt-2">
+              <button
+                onClick={() => setConfirmOverride(null)}
+                className="flex-1 rounded-xl border border-gray-200 py-2.5 text-sm font-medium text-gray-600 hover:bg-gray-50 transition-colors"
+              >
+                Anuluj
+              </button>
+              <button
+                onClick={confirmOverride.onConfirm}
+                className="flex-1 rounded-xl bg-amber-500 hover:bg-amber-600 py-2.5 text-sm font-medium text-white transition-all"
+              >
+                Nadpisz
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
     </div>
   );
 }

--- a/components/CategoryCharts.jsx
+++ b/components/CategoryCharts.jsx
@@ -322,6 +322,8 @@ export default function CategoryCharts({ transakcje = [], budgets = [], currentP
             const budgetForCat = (budgets || []).find(b => b.kategoria === item.name && (!currentPeriod || (Number(b.miesiac) === Number(currentPeriod.month) && Number(b.rok) === Number(currentPeriod.year))));
             const limit = budgetForCat ? Number(budgetForCat.limit) : null;
             const percent = limit ? Math.min(item.value / limit, 1) : null;
+            const zrodlo = budgetForCat ? budgetForCat.zrodlo : null;
+            const rocznyLimit = budgetForCat ? budgetForCat.rocznyLimit : null;
             let barColor = 'bg-emerald-400';
             if (percent !== null) {
               if (percent >= 1) barColor = 'bg-rose-500';
@@ -348,10 +350,18 @@ export default function CategoryCharts({ transakcje = [], budgets = [], currentP
                   {limit !== null && (
                     <div className="mt-2">
                       <div className="w-full bg-gray-100 rounded-full h-2 overflow-hidden">
-                        <div className={`${barColor} h-2`} style={{ width: `${(item.value / limit) * 100}%` }} />
+                        <div className={`${barColor} h-2`} style={{ width: `${Math.min((item.value / limit) * 100, 100)}%` }} />
                       </div>
                       <div className="flex items-center justify-between text-xs text-gray-500 mt-1">
-                        <span>{Math.round((item.value / limit) * 100)}% z {formatCurrency(limit)}</span>
+                        <div className="flex items-center gap-1.5">
+                          <span>{Math.round((item.value / limit) * 100)}% z {formatCurrency(limit)}</span>
+                          {zrodlo === 'monthly' && rocznyLimit !== null && (
+                            <span className="text-amber-600">(nadpisany, roczny: {formatCurrency(rocznyLimit)})</span>
+                          )}
+                          {zrodlo === 'yearly' && (
+                            <span className="text-purple-500">(roczny)</span>
+                          )}
+                        </div>
                         {item.value / limit >= 1 ? (
                           <span className="text-rose-600 font-semibold">Przekroczono</span>
                         ) : item.value / limit >= 0.8 ? (

--- a/google-apps-script/Code.gs
+++ b/google-apps-script/Code.gs
@@ -261,9 +261,18 @@ function initializeSpreadsheet() {
   let budzety = ss.getSheetByName('Budżety');
   if (!budzety) {
     budzety = ss.insertSheet('Budżety');
-    budzety.getRange('A1:D1').setValues([['Kategoria', 'Limit', 'Miesiąc', 'Rok']]);
-    budzety.getRange('A1:D1').setFontWeight('bold');
+    budzety.getRange('A1:G1').setValues([['Kategoria', 'Limit', 'Miesiąc', 'Rok', 'Osoba', 'Zakres', 'Notatki']]);
+    budzety.getRange('A1:G1').setFontWeight('bold');
     budzety.setFrozenRows(1);
+  } else {
+    // Migracja: dodaj nowe kolumny jeśli brakuje
+    const headers = budzety.getRange(1, 1, 1, budzety.getLastColumn()).getValues()[0];
+    if (headers.length < 7 || !headers.includes('Zakres')) {
+      if (headers.length < 5) budzety.getRange(1, 5).setValue('Osoba');
+      if (headers.length < 6) budzety.getRange(1, 6).setValue('Zakres');
+      if (headers.length < 7) budzety.getRange(1, 7).setValue('Notatki');
+      budzety.getRange('A1:G1').setFontWeight('bold');
+    }
   }
   
   return 'Arkusz zainicjalizowany pomyślnie!';
@@ -377,13 +386,19 @@ function doPost(e) {
       case 'setBudget':
         result = setBudget(data.budget);
         break;
+      case 'deleteBudget':
+        result = deleteBudget(data.budget);
+        break;
+      case 'getAllBudgetsForYear':
+        result = getAllBudgetsForYear(data.rok);
+        break;
       default:
         result = {error: 'Nieznana akcja'};
     }
   } catch(error) {
     result = {error: error.toString()};
   }
-  
+
   return ContentService
     .createTextOutput(JSON.stringify(result))
     .setMimeType(ContentService.MimeType.JSON);
@@ -791,9 +806,103 @@ function deleteOsoba(osoba) {
 
 // ============================================
 // BUDŻETY
-// Kolumny w arkuszu 'Budżety': Kategoria | Limit | Miesiąc | Rok
+// Kolumny w arkuszu 'Budżety': Kategoria | Limit | Miesiąc | Rok | Osoba | Zakres | Notatki
+// Zakres: "yearly" (roczny) lub "monthly" (miesięczny)
+// Hierarchia: monthly > yearly > brak
 // ============================================
+
+/**
+ * Parsuje wiersz budżetu z arkusza do obiektu.
+ * Obsługuje dane zarówno w nowym jak i starym formacie (bez Osoba/Zakres/Notatki).
+ */
+function parseBudgetRow(row) {
+  const zakres = row[5] ? String(row[5]).toLowerCase() : 'monthly';
+  return {
+    kategoria: row[0] || '',
+    limit: Number(row[1]) || 0,
+    miesiac: row[2] ? Number(row[2]) : null,
+    rok: row[3] ? Number(row[3]) : null,
+    osoba: row[4] ? String(row[4]) : '',
+    zakres: zakres,
+    notatki: row[6] ? String(row[6]) : ''
+  };
+}
+
+/**
+ * Pobiera rozwiązane (resolved) budżety dla danego miesiąca/roku.
+ * Stosuje hierarchię: monthly > yearly > brak.
+ * Każdy zwrócony budżet zawiera pole 'zrodlo' (source) wskazujące
+ * czy pochodzi z budżetu miesięcznego czy rocznego,
+ * oraz opcjonalnie 'rocznyLimit' jeśli istnieje budżet roczny nadpisany miesięcznym.
+ */
 function getBudgets(miesiac, rok) {
+  const ss = SpreadsheetApp.openById(SPREADSHEET_ID);
+  const sheet = ss.getSheetByName('Budżety');
+  if (!sheet) return [];
+
+  const data = sheet.getDataRange().getValues();
+
+  // Zbierz wszystkie budżety dla danego roku
+  const yearlyMap = {};  // klucz: "kategoria|osoba" → budget
+  const monthlyMap = {}; // klucz: "kategoria|osoba" → budget
+
+  for (let i = 1; i < data.length; i++) {
+    const row = data[i];
+    if (!row[0]) continue;
+
+    const budget = parseBudgetRow(row);
+
+    // Filtruj po roku
+    if (rok && budget.rok !== Number(rok)) continue;
+
+    const key = budget.kategoria + '|' + (budget.osoba || '');
+
+    if (budget.zakres === 'yearly') {
+      yearlyMap[key] = budget;
+    } else {
+      // monthly (lub brak zakres - kompatybilność wsteczna)
+      if (miesiac && budget.miesiac === Number(miesiac)) {
+        monthlyMap[key] = budget;
+      }
+    }
+  }
+
+  // Rozwiąż hierarchię
+  const resolved = [];
+  const allKeys = new Set([...Object.keys(yearlyMap), ...Object.keys(monthlyMap)]);
+
+  for (const key of allKeys) {
+    const monthly = monthlyMap[key];
+    const yearly = yearlyMap[key];
+
+    if (monthly) {
+      // Budżet miesięczny ma priorytet
+      resolved.push({
+        ...monthly,
+        zrodlo: 'monthly',
+        rocznyLimit: yearly ? yearly.limit : null,
+        roczneNotatki: yearly ? yearly.notatki : null
+      });
+    } else if (yearly) {
+      // Użyj budżetu rocznego
+      resolved.push({
+        ...yearly,
+        miesiac: Number(miesiac), // ustaw miesiąc dla wyświetlania
+        zrodlo: 'yearly',
+        rocznyLimit: yearly.limit,
+        roczneNotatki: yearly.notatki
+      });
+    }
+  }
+
+  return resolved;
+}
+
+/**
+ * Pobiera wszystkie surowe budżety dla roku (bez rozwiązywania hierarchii).
+ * Używane w panelu zarządzania budżetami.
+ */
+function getAllBudgetsForYear(rok) {
   const ss = SpreadsheetApp.openById(SPREADSHEET_ID);
   const sheet = ss.getSheetByName('Budżety');
   if (!sheet) return [];
@@ -804,24 +913,22 @@ function getBudgets(miesiac, rok) {
   for (let i = 1; i < data.length; i++) {
     const row = data[i];
     if (!row[0]) continue;
-    const bMonth = row[2] ? Number(row[2]) : null;
-    const bYear = row[3] ? Number(row[3]) : null;
 
-    if (miesiac && rok) {
-      if (Number(miesiac) !== bMonth || Number(rok) !== bYear) continue;
-    }
+    const budget = parseBudgetRow(row);
 
-    budgets.push({
-      kategoria: row[0],
-      limit: Number(row[1]) || 0,
-      miesiac: bMonth,
-      rok: bYear
-    });
+    if (rok && budget.rok !== Number(rok)) continue;
+
+    budgets.push(budget);
   }
 
   return budgets;
 }
 
+/**
+ * Ustawia (tworzy lub aktualizuje) budżet.
+ * Klucz unikatowy: (kategoria, osoba, zakres, rok, miesiac)
+ * Dla yearly: miesiac jest ignorowany (null).
+ */
 function setBudget(budget) {
   if (!budget || !budget.kategoria) return { success: false, error: 'Brak danych budżetu' };
 
@@ -830,24 +937,66 @@ function setBudget(budget) {
   if (!sheet) return { success: false, error: 'Arkusz Budżety nie istnieje' };
 
   const data = sheet.getDataRange().getValues();
-  const targetMonth = budget.miesiac ? Number(budget.miesiac) : null;
+  const zakres = budget.zakres || 'monthly';
+  const targetMonth = zakres === 'yearly' ? null : (budget.miesiac ? Number(budget.miesiac) : null);
   const targetYear = budget.rok ? Number(budget.rok) : null;
+  const osoba = budget.osoba || '';
   const limit = Number(budget.limit) || 0;
+  const notatki = budget.notatki || '';
 
-  // Szukaj istniejącego wpisu (kategoria + miesiąc + rok)
+  // Szukaj istniejącego wpisu (kategoria + osoba + zakres + rok + miesiac)
   for (let i = 1; i < data.length; i++) {
     const row = data[i];
-    const rowCat = row[0];
-    const rowMonth = row[2] ? Number(row[2]) : null;
-    const rowYear = row[3] ? Number(row[3]) : null;
+    const existing = parseBudgetRow(row);
 
-    if (rowCat === budget.kategoria && rowMonth === targetMonth && rowYear === targetYear) {
-      sheet.getRange(i + 1, 2).setValue(limit);
+    if (existing.kategoria === budget.kategoria &&
+        (existing.osoba || '') === osoba &&
+        existing.zakres === zakres &&
+        existing.rok === targetYear &&
+        (zakres === 'yearly' || existing.miesiac === targetMonth)) {
+      // Aktualizuj istniejący wiersz
+      sheet.getRange(i + 1, 1, 1, 7).setValues([[
+        budget.kategoria, limit, targetMonth || '', targetYear || '', osoba, zakres, notatki
+      ]]);
       return { success: true, message: 'Zaktualizowano budżet' };
     }
   }
 
   // Jeśli nie znaleziono — dopisz nowy wiersz
-  sheet.appendRow([budget.kategoria, limit, targetMonth || '', targetYear || '']);
+  sheet.appendRow([budget.kategoria, limit, targetMonth || '', targetYear || '', osoba, zakres, notatki]);
   return { success: true, message: 'Dodano budżet' };
+}
+
+/**
+ * Usuwa budżet.
+ * Identyfikuje po: (kategoria, osoba, zakres, rok, miesiac)
+ */
+function deleteBudget(budget) {
+  if (!budget || !budget.kategoria) return { success: false, error: 'Brak danych budżetu' };
+
+  const ss = SpreadsheetApp.openById(SPREADSHEET_ID);
+  const sheet = ss.getSheetByName('Budżety');
+  if (!sheet) return { success: false, error: 'Arkusz Budżety nie istnieje' };
+
+  const data = sheet.getDataRange().getValues();
+  const zakres = budget.zakres || 'monthly';
+  const targetMonth = zakres === 'yearly' ? null : (budget.miesiac ? Number(budget.miesiac) : null);
+  const targetYear = budget.rok ? Number(budget.rok) : null;
+  const osoba = budget.osoba || '';
+
+  for (let i = 1; i < data.length; i++) {
+    const row = data[i];
+    const existing = parseBudgetRow(row);
+
+    if (existing.kategoria === budget.kategoria &&
+        (existing.osoba || '') === osoba &&
+        existing.zakres === zakres &&
+        existing.rok === targetYear &&
+        (zakres === 'yearly' || existing.miesiac === targetMonth)) {
+      sheet.deleteRow(i + 1);
+      return { success: true, message: 'Usunięto budżet' };
+    }
+  }
+
+  return { success: false, error: 'Nie znaleziono budżetu do usunięcia' };
 }

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1629,6 +1629,7 @@ export default function BudgetApp() {
           month={currentPeriod.month}
           year={currentPeriod.year}
           budgets={budgets}
+          osoby={osoby}
           authToken={token}
           onSaved={async () => {
             try {


### PR DESCRIPTION
Implement yearly and monthly budget scopes with automatic hierarchy resolution (monthly overrides yearly). Key changes:

Backend (Code.gs):
- Extended budget sheet: Kategoria|Limit|Miesiąc|Rok|Osoba|Zakres|Notatki
- getBudgets() now resolves hierarchy: monthly > yearly per category
- New getAllBudgetsForYear() for budget management UI
- New deleteBudget() endpoint
- setBudget() updated for new fields (osoba, zakres, notatki)
- Backward-compatible migration for existing budget data

Frontend (Budgets.jsx):
- Scope toggle (monthly/yearly) with visual distinction
- Person selector (all people or specific person)
- Notes field for budget entries
- Tree view showing yearly budgets with monthly overrides
- Edit/delete functionality for both budget types
- Warning dialog when creating monthly override of yearly budget

Frontend (CategoryCharts.jsx):
- Budget source indicator (yearly vs monthly override)
- Shows original yearly limit when overridden by monthly budget

https://claude.ai/code/session_017FpGnYW2an2Zrxm8vNrG4r