### PR TITLE
fix: generate UUID for transactions without valid ID in CSV

### DIFF
--- a/migration/migrate.mjs
+++ b/migration/migrate.mjs
@@ -15,6 +15,7 @@
 
 import fs from 'fs';
 import path from 'path';
+import crypto from 'crypto';
 import { fileURLToPath } from 'url';
 import { createClient } from '@supabase/supabase-js';
 import Papa from 'papaparse';
@@ -187,10 +188,10 @@ function transformTransakcje(rows, householdId) {
         komentarz: (row['Komentarz'] || '').trim() || null,
       };
 
-      // Zachowaj istniejące UUID jeśli jest
-      if (id && isValidUUID(id)) {
-        record.id = id;
-      }
+      // Zachowaj istniejące UUID lub wygeneruj nowy
+      // (batch insert wymaga id we WSZYSTKICH rekordach — inaczej Supabase
+      //  wstawia NULL dla brakujących, łamiąc NOT NULL constraint)
+      record.id = id && isValidUUID(id) ? id : crypto.randomUUID();
 
       return record;
     })


### PR DESCRIPTION
Batch inserts require all records to have the same columns. When some records had 'id' (valid UUID from Sheets) and others didn't, Supabase included the id column for all rows, setting NULL for those without it — violating the NOT NULL constraint.

Now generates crypto.randomUUID() for records with non-UUID IDs (t-001 etc).

https://claude.ai/code/session_01GhR5TDxApAPUijWciRipMz