### PR TITLE
feat: migrate frontend API layer from Google Apps Script to Supabase

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,2 +1,4 @@
-VITE_API_URL=https://script.google.com/macros/s/TWOJ_KLUCZ/exec
+VITE_SUPABASE_URL=https://twoj-projekt.supabase.co
+VITE_SUPABASE_ANON_KEY=twoj-anon-key
+VITE_HOUSEHOLD_ID=twoj-household-uuid
 VITE_GOOGLE_CLIENT_ID=TWOJ_GOOGLE_CLIENT_ID.apps.googleusercontent.com

--- a/components/Budgets.jsx
+++ b/components/Budgets.jsx
@@ -1,4 +1,5 @@
 import React, { useState, useMemo, useEffect } from 'react';
+import * as api from '../src/services/api';
 
 const formatCurrency = (value) => {
   return new Intl.NumberFormat('pl-PL', {
@@ -14,7 +15,7 @@ const MONTH_NAMES = [
   'Lipiec', 'Sierpień', 'Wrzesień', 'Październik', 'Listopad', 'Grudzień'
 ];
 
-export default function Budgets({ onClose, kategorie = {}, apiUrl, month, year, budgets = [], onSaved, authToken, osoby = [] }) {
+export default function Budgets({ onClose, kategorie = {}, month, year, budgets = [], onSaved, osoby = [] }) {
   const expenseCats = Object.keys(kategorie['Wydatek'] || {});
 
   const [form, setForm] = useState({
@@ -36,14 +37,8 @@ export default function Budgets({ onClose, kategorie = {}, apiUrl, month, year, 
   const fetchAllBudgets = async () => {
     setIsLoadingAll(true);
     try {
-      const res = await fetch(apiUrl, {
-        method: 'POST',
-        body: JSON.stringify({ action: 'getAllBudgetsForYear', rok: form.rok, token: authToken })
-      });
-      const data = await res.json();
-      if (!data.error) {
-        setAllBudgets(Array.isArray(data) ? data : []);
-      }
+      const data = await api.getAllBudgetsForYear(form.rok);
+      setAllBudgets(Array.isArray(data) ? data : []);
     } catch (err) {
       console.warn('Nie udało się pobrać budżetów rocznych', err);
     } finally {
@@ -122,21 +117,15 @@ export default function Budgets({ onClose, kategorie = {}, apiUrl, month, year, 
         budgetData.miesiac = Number(form.miesiac);
       }
 
-      const res = await fetch(apiUrl, {
-        method: 'POST',
-        body: JSON.stringify({ action: 'setBudget', budget: budgetData, token: authToken })
-      });
-      const data = await res.json();
+      const data = await api.setBudget(budgetData);
       if (data.success) {
         await fetchAllBudgets();
         if (onSaved) onSaved();
         setForm(prev => ({ ...prev, limit: '', notatki: '' }));
-      } else {
-        alert(data.error || 'Błąd zapisu budżetu');
       }
     } catch (err) {
       console.error(err);
-      alert('Błąd połączenia');
+      alert(err.message || 'Błąd zapisu budżetu');
     } finally {
       setIsSaving(false);
     }
@@ -146,20 +135,14 @@ export default function Budgets({ onClose, kategorie = {}, apiUrl, month, year, 
     if (!window.confirm(`Czy na pewno chcesz usunąć budżet ${budget.zakres === 'yearly' ? 'roczny' : 'miesięczny'} dla "${budget.kategoria}"?`)) return;
 
     try {
-      const res = await fetch(apiUrl, {
-        method: 'POST',
-        body: JSON.stringify({ action: 'deleteBudget', budget, token: authToken })
-      });
-      const data = await res.json();
+      const data = await api.deleteBudget(budget);
       if (data.success) {
         await fetchAllBudgets();
         if (onSaved) onSaved();
-      } else {
-        alert(data.error || 'Błąd usuwania budżetu');
       }
     } catch (err) {
       console.error(err);
-      alert('Błąd połączenia');
+      alert(err.message || 'Błąd usuwania budżetu');
     }
   };
 

--- a/components/CSVImport.jsx
+++ b/components/CSVImport.jsx
@@ -1,5 +1,6 @@
 import React, { useState, useEffect, useCallback } from 'react';
 import Papa from 'papaparse';
+import * as api from '../src/services/api';
 
 // Mapowanie słów kluczowych na kategorie
 const categoryMapping = {
@@ -91,25 +92,8 @@ const categorizeDescription = (description, userRules = []) => {
 const STORAGE_KEY = 'csv_import_progress';
 const RULES_STORAGE_KEY = 'csv_recognition_rules';
 
-// Check if JWT token is expired (with 60s buffer)
-function checkTokenExpired(token) {
-  try {
-    const base64Url = token.split('.')[1];
-    const base64 = base64Url.replace(/-/g, '+').replace(/_/g, '/');
-    const payload = JSON.parse(decodeURIComponent(
-      atob(base64)
-        .split('')
-        .map(c => '%' + ('00' + c.charCodeAt(0).toString(16)).slice(-2))
-        .join('')
-    ));
-    if (!payload || !payload.exp) return true;
-    return Date.now() >= (payload.exp - 60) * 1000;
-  } catch {
-    return true;
-  }
-}
 
-export default function CSVImport({ onClose, apiUrl, kategorie = {}, onSaved, authToken }) {
+export default function CSVImport({ onClose, kategorie = {}, onSaved }) {
   const [step, setStep] = useState(1); // 1: Upload, 2: Mapping, 3: Preview, 4: Success
   const [csvData, setCsvData] = useState(null);
   const [headers, setHeaders] = useState([]);
@@ -121,7 +105,6 @@ export default function CSVImport({ onClose, apiUrl, kategorie = {}, onSaved, au
   const [transactions, setTransactions] = useState([]);
   const [isLoading, setIsLoading] = useState(false);
   const [lastSaved, setLastSaved] = useState(null);
-  const [sessionError, setSessionError] = useState(false);
 
   // Feature 6: Recognition rules
   const [recognitionRules, setRecognitionRules] = useState([]);
@@ -185,24 +168,6 @@ export default function CSVImport({ onClose, apiUrl, kategorie = {}, onSaved, au
       }
     }
   }, [transactions, step]);
-
-  // Heartbeat - keep session alive during category mapping (step 3)
-  useEffect(() => {
-    if (step !== 3 || !apiUrl || !authToken) return;
-
-    const heartbeat = setInterval(async () => {
-      try {
-        await fetch(apiUrl, {
-          method: 'POST',
-          body: JSON.stringify({ action: 'keepAlive', token: authToken }),
-        });
-      } catch (e) {
-        console.error('Session heartbeat failed:', e);
-      }
-    }, 5 * 60 * 1000); // every 5 minutes
-
-    return () => clearInterval(heartbeat);
-  }, [step, apiUrl, authToken]);
 
   // Auto-dismiss rule notification after 4 seconds
   useEffect(() => {
@@ -376,12 +341,6 @@ export default function CSVImport({ onClose, apiUrl, kategorie = {}, onSaved, au
       return;
     }
 
-    // Check token validity before attempting import
-    if (checkTokenExpired(authToken)) {
-      setSessionError(true);
-      return;
-    }
-
     setIsLoading(true);
     try {
       // Normalize kwota to numbers and update typ based on final amount
@@ -398,30 +357,16 @@ export default function CSVImport({ onClose, apiUrl, kategorie = {}, onSaved, au
         };
       });
 
-      const res = await fetch(apiUrl, {
-        method: 'POST',
-        body: JSON.stringify({
-          action: 'addTransakcjeBatch',
-          transakcje: normalizedTransactions,
-          token: authToken
-        })
-      });
-      const data = await res.json();
+      const data = await api.addTransakcjeBatch(normalizedTransactions);
 
       if (data.success) {
         localStorage.removeItem(STORAGE_KEY);
         setStep(4);
         if (onSaved) onSaved();
-      } else if (data.error && (data.error.toLowerCase().includes('token') || data.error.toLowerCase().includes('auth') || data.error.toLowerCase().includes('unauthorized'))) {
-        setSessionError(true);
-        setIsLoading(false);
-      } else {
-        alert(data.error || 'Błąd importu');
-        setIsLoading(false);
       }
     } catch (err) {
       console.error(err);
-      alert('Błąd połączenia. Twój postęp został zapisany lokalnie.');
+      alert(err.message || 'Błąd importu. Twój postęp został zapisany lokalnie.');
       setIsLoading(false);
     }
   };
@@ -441,11 +386,6 @@ export default function CSVImport({ onClose, apiUrl, kategorie = {}, onSaved, au
       localStorage.removeItem(STORAGE_KEY);
     }
     onClose();
-  };
-
-  const handleRelogin = () => {
-    // Progress is already saved in localStorage; redirect to re-authenticate
-    window.location.reload();
   };
 
   // Feature 7: Toggle row details on mobile
@@ -487,23 +427,6 @@ export default function CSVImport({ onClose, apiUrl, kategorie = {}, onSaved, au
 
         {/* Content */}
         <div className="p-6 overflow-auto flex-1">
-          {/* Session expired error */}
-          {sessionError && (
-            <div className="mb-4 bg-red-50 border border-red-300 rounded-lg p-4">
-              <h4 className="font-semibold text-red-800 mb-1">Sesja wygasła</h4>
-              <p className="text-sm text-red-700 mb-3">
-                Twoja sesja wygasła, ale postęp został zapisany lokalnie.
-                Zaloguj się ponownie, aby kontynuować import.
-              </p>
-              <button
-                onClick={handleRelogin}
-                className="px-4 py-2 bg-red-600 text-white rounded hover:bg-red-700 text-sm"
-              >
-                Zaloguj ponownie
-              </button>
-            </div>
-          )}
-
           {/* Step 1: Upload */}
           {step === 1 && (
             <div className="space-y-4">
@@ -942,7 +865,7 @@ export default function CSVImport({ onClose, apiUrl, kategorie = {}, onSaved, au
                 </button>
                 <button
                   onClick={handleImport}
-                  disabled={isLoading || sessionError}
+                  disabled={isLoading}
                   className="flex-1 px-4 py-2 bg-green-600 text-white rounded hover:bg-green-700 disabled:opacity-50"
                 >
                   {isLoading ? 'Importuję...' : 'Importuj transakcje'}

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
+        "@supabase/supabase-js": "^2.95.3",
         "papaparse": "^5.5.3",
         "react": "19.2.4",
         "react-dom": "19.2.4",
@@ -1216,6 +1217,86 @@
       "integrity": "sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==",
       "license": "MIT"
     },
+    "node_modules/@supabase/auth-js": {
+      "version": "2.95.3",
+      "resolved": "https://registry.npmjs.org/@supabase/auth-js/-/auth-js-2.95.3.tgz",
+      "integrity": "sha512-vD2YoS8E2iKIX0F7EwXTmqhUpaNsmbU6X2R0/NdFcs02oEfnHyNP/3M716f3wVJ2E5XHGiTFXki6lRckhJ0Thg==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "2.8.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@supabase/functions-js": {
+      "version": "2.95.3",
+      "resolved": "https://registry.npmjs.org/@supabase/functions-js/-/functions-js-2.95.3.tgz",
+      "integrity": "sha512-uTuOAKzs9R/IovW1krO0ZbUHSJnsnyJElTXIRhjJTqymIVGcHzkAYnBCJqd7468Fs/Foz1BQ7Dv6DCl05lr7ig==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "2.8.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@supabase/postgrest-js": {
+      "version": "2.95.3",
+      "resolved": "https://registry.npmjs.org/@supabase/postgrest-js/-/postgrest-js-2.95.3.tgz",
+      "integrity": "sha512-LTrRBqU1gOovxRm1vRXPItSMPBmEFqrfTqdPTRtzOILV4jPSueFz6pES5hpb4LRlkFwCPRmv3nQJ5N625V2Xrg==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "2.8.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@supabase/realtime-js": {
+      "version": "2.95.3",
+      "resolved": "https://registry.npmjs.org/@supabase/realtime-js/-/realtime-js-2.95.3.tgz",
+      "integrity": "sha512-D7EAtfU3w6BEUxDACjowWNJo/ZRo7sDIuhuOGKHIm9FHieGeoJV5R6GKTLtga/5l/6fDr2u+WcW/m8I9SYmaIw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/phoenix": "^1.6.6",
+        "@types/ws": "^8.18.1",
+        "tslib": "2.8.1",
+        "ws": "^8.18.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@supabase/storage-js": {
+      "version": "2.95.3",
+      "resolved": "https://registry.npmjs.org/@supabase/storage-js/-/storage-js-2.95.3.tgz",
+      "integrity": "sha512-4GxkJiXI3HHWjxpC3sDx1BVrV87O0hfX+wvJdqGv67KeCu+g44SPnII8y0LL/Wr677jB7tpjAxKdtVWf+xhc9A==",
+      "license": "MIT",
+      "dependencies": {
+        "iceberg-js": "^0.8.1",
+        "tslib": "2.8.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@supabase/supabase-js": {
+      "version": "2.95.3",
+      "resolved": "https://registry.npmjs.org/@supabase/supabase-js/-/supabase-js-2.95.3.tgz",
+      "integrity": "sha512-Fukw1cUTQ6xdLiHDJhKKPu6svEPaCEDvThqCne3OaQyZvuq2qjhJAd91kJu3PXLG18aooCgYBaB6qQz35hhABg==",
+      "license": "MIT",
+      "dependencies": {
+        "@supabase/auth-js": "2.95.3",
+        "@supabase/functions-js": "2.95.3",
+        "@supabase/postgrest-js": "2.95.3",
+        "@supabase/realtime-js": "2.95.3",
+        "@supabase/storage-js": "2.95.3"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
     "node_modules/@tailwindcss/node": {
       "version": "4.1.18",
       "resolved": "https://registry.npmjs.org/@tailwindcss/node/-/node-4.1.18.tgz",
@@ -1602,11 +1683,35 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/node": {
+      "version": "25.2.3",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.2.3.tgz",
+      "integrity": "sha512-m0jEgYlYz+mDJZ2+F4v8D1AyQb+QzsNqRuI7xg1VQX/KlKS0qT9r1Mo16yo5F/MtifXFgaofIFsdFMox2SxIbQ==",
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.16.0"
+      }
+    },
+    "node_modules/@types/phoenix": {
+      "version": "1.6.7",
+      "resolved": "https://registry.npmjs.org/@types/phoenix/-/phoenix-1.6.7.tgz",
+      "integrity": "sha512-oN9ive//QSBkf19rfDv45M7eZPi0eEXylht2OLEXicu5b4KoQ1OzXIw+xDSGWxSxe1JmepRR/ZH283vsu518/Q==",
+      "license": "MIT"
+    },
     "node_modules/@types/use-sync-external-store": {
       "version": "0.0.6",
       "resolved": "https://registry.npmjs.org/@types/use-sync-external-store/-/use-sync-external-store-0.0.6.tgz",
       "integrity": "sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg==",
       "license": "MIT"
+    },
+    "node_modules/@types/ws": {
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
+      "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
     },
     "node_modules/@vitejs/plugin-react": {
       "version": "4.7.0",
@@ -2054,6 +2159,15 @@
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/iceberg-js": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/iceberg-js/-/iceberg-js-0.8.1.tgz",
+      "integrity": "sha512-1dhVQZXhcHje7798IVM+xoo/1ZdVfzOMIc8/rgVSijRK38EDqOJoGula9N/8ZI5RD8QTxNQtK/Gozpr+qUqRRA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.0.0"
+      }
     },
     "node_modules/immer": {
       "version": "10.2.0",
@@ -2729,6 +2843,18 @@
         "url": "https://github.com/sponsors/SuperchupuDev"
       }
     },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/undici-types": {
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
+      "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
+      "license": "MIT"
+    },
     "node_modules/update-browserslist-db": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
@@ -2862,6 +2988,27 @@
           "optional": true
         },
         "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ws": {
+      "version": "8.19.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.19.0.tgz",
+      "integrity": "sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
           "optional": true
         }
       }

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "@supabase/supabase-js": "^2.95.3",
     "papaparse": "^5.5.3",
     "react": "19.2.4",
     "react-dom": "19.2.4",

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -8,29 +8,7 @@ import { useAuth } from './contexts/AuthContext';
 import { useToast } from './contexts/ToastContext';
 import { useOffline } from './hooks/useOffline';
 import { addToQueue, getQueuedOperations, processQueue } from './services/offlineQueue';
-
-// Sprawdź czy zmienna środowiskowa jest ustawiona
-if (!import.meta.env.VITE_API_URL) {
-  throw new Error(
-    '❌ VITE_API_URL nie jest ustawiona!\n' +
-    '📝 Utwórz plik .env w głównym katalogu projektu:\n' +
-    'VITE_API_URL=https://script.google.com/macros/s/TWÓJ_KLUCZ/exec'
-  );
-}
-
-const API_URL = import.meta.env.VITE_API_URL;
-
-// Log dla debugowania (usuń po wdrożeniu)
-//console.log('🔧 API_URL:', API_URL);
-
-// Authenticated fetch — always use POST to avoid token-in-URL length issues
-const authFetch = (url, body, token) => {
-  const data = typeof body === 'string' ? JSON.parse(body) : body;
-  return fetch(url, {
-    method: 'POST',
-    body: JSON.stringify({ ...data, token }),
-  });
-};
+import * as api from './services/api';
 
 // Pomocnicze funkcje
 const formatCurrency = (amount) => {
@@ -468,7 +446,7 @@ const TransactionItem = ({ transaction, onDelete, onEdit, isOffline, addToast })
 // ============================================
 // PANEL USTAWIEŃ - Zarządzanie słownikami
 // ============================================
-const SettingsPanel = ({ onClose, kategorie, osoby, transakcje, onKategorieChange, onOsobyChange, apiUrl, authToken }) => {
+const SettingsPanel = ({ onClose, kategorie, osoby, transakcje, onKategorieChange, onOsobyChange }) => {
   const [activeTab, setActiveTab] = useState('kategorie');
   const [isProcessing, setIsProcessing] = useState(false);
   const [settingsError, setSettingsError] = useState(null);
@@ -540,14 +518,8 @@ const SettingsPanel = ({ onClose, kategorie, osoby, transakcje, onKategorieChang
     
     setIsProcessing(true);
     try {
-      const res = await authFetch(apiUrl, {
-          action: 'addKategoria',
-          typ: newKatTyp,
-          kategoria: nazwa,
-          podkategoria: podkat
-        }, authToken);
-      const result = await res.json();
-      
+      const result = await api.addKategoria(newKatTyp, nazwa, podkat);
+
       if (result.success) {
         const updated = { ...kategorie };
         if (!updated[newKatTyp]) updated[newKatTyp] = {};
@@ -597,14 +569,8 @@ const SettingsPanel = ({ onClose, kategorie, osoby, transakcje, onKategorieChang
     setIsProcessing(true);
     
     try {
-      const res = await authFetch(apiUrl, {
-          action: 'deleteKategoria',
-          typ,
-          kategoria,
-          podkategoria: podkategoria || ''
-        }, authToken);
-      const result = await res.json();
-      
+      const result = await api.deleteKategoria(typ, kategoria, podkategoria);
+
       if (result.success) {
         const updated = { ...kategorie };
         if (podkategoria) {
@@ -640,12 +606,8 @@ const SettingsPanel = ({ onClose, kategorie, osoby, transakcje, onKategorieChang
     
     setIsProcessing(true);
     try {
-      const res = await authFetch(apiUrl, {
-          action: 'addOsoba',
-          osoba: nazwa
-        }, authToken);
-      const result = await res.json();
-      
+      const result = await api.addOsoba(nazwa);
+
       if (result.success) {
         onOsobyChange([...osoby, nazwa]);
         setNewOsoba('');
@@ -686,12 +648,8 @@ const SettingsPanel = ({ onClose, kategorie, osoby, transakcje, onKategorieChang
     setIsProcessing(true);
     
     try {
-      const res = await authFetch(apiUrl, {
-          action: 'deleteOsoba',
-          osoba
-        }, authToken);
-      const result = await res.json();
-      
+      const result = await api.deleteOsoba(osoba);
+
       if (result.success) {
         onOsobyChange(osoby.filter(o => o !== osoba));
         showSuccess(`Usunięto osobę "${osoba}"`);
@@ -1084,36 +1042,20 @@ export default function BudgetApp() {
 
     // 2. Pobierz świeże dane w tle
     try {
-      const response = await authFetch(API_URL, {
-          action: 'getAllData',
-          miesiac: currentPeriod.month,
-          rok: currentPeriod.year
-        }, token);
-      const data = await response.json();
-      
-      if (data.error) {
-        throw new Error(data.error);
-      }
-      
+      const data = await api.getAllData(currentPeriod.month, currentPeriod.year);
+
       // Aktualizuj stan
       const noweTransakcje = Array.isArray(data.transakcje) ? data.transakcje : [];
       const noweKategorie = data.kategorie || { Wydatek: {}, Przychód: {} };
       const noweOsoby = Array.isArray(data.osoby) ? data.osoby : [];
-      
+
       setTransakcje(noweTransakcje);
       setKategorie(noweKategorie);
       setOsoby(noweOsoby);
       // Pobierz budżety dla okresu
       try {
-        const bRes = await authFetch(API_URL, {
-            action: 'getBudgets',
-            miesiac: currentPeriod.month,
-            rok: currentPeriod.year
-          }, token);
-        const bData = await bRes.json();
-        if (!bData.error) {
-          setBudgets(Array.isArray(bData) ? bData : []);
-        }
+        const bData = await api.getBudgets(currentPeriod.month, currentPeriod.year);
+        setBudgets(Array.isArray(bData) ? bData : []);
       } catch (err) {
         console.warn('Nie udało się pobrać budżetów', err);
       }
@@ -1126,14 +1068,14 @@ export default function BudgetApp() {
     } catch (err) {
       // Pokaż błąd tylko jeśli nie mamy cache
       if (!hasCache) {
-        setError('Nie udało się połączyć z arkuszem. Sprawdź połączenie i odśwież stronę.');
+        setError('Nie udało się pobrać danych. Sprawdź połączenie i odśwież stronę.');
       }
       console.error(err);
     } finally {
       setIsLoading(false);
       setIsRefreshing(false);
     }
-  }, [currentPeriod, token]);
+  }, [currentPeriod]);
 
   // Ładuj dane przy starcie i zmianie miesiąca
   useEffect(() => {
@@ -1142,7 +1084,7 @@ export default function BudgetApp() {
 
   // Sync queued operations when coming back online
   useEffect(() => {
-    if (wasOfflineRef.current && !isOffline && token) {
+    if (wasOfflineRef.current && !isOffline) {
       const syncQueue = async () => {
         const queue = getQueuedOperations();
         if (queue.length === 0) {
@@ -1151,7 +1093,7 @@ export default function BudgetApp() {
         }
         setIsSyncing(true);
         try {
-          const result = await processQueue(authFetch, API_URL, token);
+          const result = await processQueue();
           if (result.succeeded > 0) {
             addToast(`Zsynchronizowano ${result.succeeded} ${result.succeeded === 1 ? 'operację' : 'operacji'}`);
           }
@@ -1168,7 +1110,7 @@ export default function BudgetApp() {
       syncQueue();
     }
     wasOfflineRef.current = isOffline;
-  }, [isOffline, token, fetchData, addToast]);
+  }, [isOffline, fetchData, addToast]);
 
   // Dodawanie transakcji
   const handleAddTransaction = async (transakcja) => {
@@ -1191,11 +1133,7 @@ export default function BudgetApp() {
 
     setIsSaving(true);
     try {
-      const res = await authFetch(API_URL, {
-          action: 'addTransakcja',
-          transakcja
-        }, token);
-      const result = await res.json();
+      const result = await api.addTransakcja(transakcja);
 
       if (result.success) {
         await fetchData();
@@ -1237,12 +1175,7 @@ export default function BudgetApp() {
 
     setIsSaving(true);
     try {
-      const res = await authFetch(API_URL, {
-          action: 'updateTransakcja',
-          id: editingTransaction.id,
-          transakcja
-        }, token);
-      const result = await res.json();
+      const result = await api.updateTransakcja(editingTransaction.id, transakcja);
 
       if (result.success) {
         await fetchData();
@@ -1294,11 +1227,7 @@ export default function BudgetApp() {
     }
 
     try {
-      const res = await authFetch(API_URL, {
-          action: 'deleteTransakcja',
-          id
-        }, token);
-      const result = await res.json();
+      const result = await api.deleteTransakcja(id);
       if (result.success !== false) {
         await fetchData();
         addToast('Transakcja została usunięta');
@@ -1616,8 +1545,6 @@ export default function BudgetApp() {
           transakcje={transakcje}
           onKategorieChange={handleKategorieChange}
           onOsobyChange={handleOsobyChange}
-          apiUrl={API_URL}
-          authToken={token}
         />
       )}
 
@@ -1625,21 +1552,14 @@ export default function BudgetApp() {
         <Budgets
           onClose={() => setShowBudgets(false)}
           kategorie={kategorie}
-          apiUrl={API_URL}
           month={currentPeriod.month}
           year={currentPeriod.year}
           budgets={budgets}
           osoby={osoby}
-          authToken={token}
           onSaved={async () => {
             try {
-              const bRes = await authFetch(API_URL, {
-            action: 'getBudgets',
-            miesiac: currentPeriod.month,
-            rok: currentPeriod.year
-          }, token);
-              const bData = await bRes.json();
-              if (!bData.error) setBudgets(Array.isArray(bData) ? bData : []);
+              const bData = await api.getBudgets(currentPeriod.month, currentPeriod.year);
+              setBudgets(Array.isArray(bData) ? bData : []);
             } catch (err) {
               console.warn('Nie udało się odświeżyć budżetów', err);
             }
@@ -1651,8 +1571,6 @@ export default function BudgetApp() {
         <CSVImport
           onClose={() => setShowCSVImport(false)}
           kategorie={kategorie}
-          apiUrl={API_URL}
-          authToken={token}
           onSaved={() => {
             setShowCSVImport(false);
             fetchData();

--- a/src/lib/supabase.js
+++ b/src/lib/supabase.js
@@ -1,0 +1,15 @@
+import { createClient } from '@supabase/supabase-js';
+
+const supabaseUrl = import.meta.env.VITE_SUPABASE_URL;
+const supabaseAnonKey = import.meta.env.VITE_SUPABASE_ANON_KEY;
+
+if (!supabaseUrl || !supabaseAnonKey) {
+  throw new Error(
+    'Brak konfiguracji Supabase!\n' +
+    'Utwórz plik .env.local z:\n' +
+    'VITE_SUPABASE_URL=https://twoj-projekt.supabase.co\n' +
+    'VITE_SUPABASE_ANON_KEY=twoj-anon-key'
+  );
+}
+
+export const supabase = createClient(supabaseUrl, supabaseAnonKey);

--- a/src/services/api.js
+++ b/src/services/api.js
@@ -1,0 +1,377 @@
+import { supabase } from '../lib/supabase';
+
+const HOUSEHOLD_ID = import.meta.env.VITE_HOUSEHOLD_ID;
+
+if (!HOUSEHOLD_ID) {
+  throw new Error(
+    'Brak VITE_HOUSEHOLD_ID!\n' +
+    'Dodaj do .env.local:\n' +
+    'VITE_HOUSEHOLD_ID=twoj-household-uuid'
+  );
+}
+
+// ═══════════════════════════════════════════
+// TRANSAKCJE
+// ═══════════════════════════════════════════
+
+export async function getTransakcje(miesiac, rok) {
+  const startDate = `${rok}-${String(miesiac).padStart(2, '0')}-01`;
+  const endDate = miesiac === 12
+    ? `${rok + 1}-01-01`
+    : `${rok}-${String(miesiac + 1).padStart(2, '0')}-01`;
+
+  const { data, error } = await supabase
+    .from('transakcje')
+    .select('id, data, typ, kwota, kategoria, podkategoria, osoba, komentarz')
+    .eq('household_id', HOUSEHOLD_ID)
+    .gte('data', startDate)
+    .lt('data', endDate)
+    .order('data', { ascending: false });
+
+  if (error) throw error;
+  return data;
+}
+
+export async function addTransakcja(transakcja) {
+  const { data, error } = await supabase
+    .from('transakcje')
+    .insert({
+      household_id: HOUSEHOLD_ID,
+      data: transakcja.data,
+      typ: transakcja.typ,
+      kwota: Math.abs(transakcja.kwota),
+      kategoria: transakcja.kategoria,
+      podkategoria: transakcja.podkategoria || null,
+      osoba: transakcja.osoba,
+      komentarz: transakcja.komentarz || null,
+    })
+    .select('id')
+    .single();
+
+  if (error) throw error;
+  return { success: true, id: data.id };
+}
+
+export async function updateTransakcja(id, transakcja) {
+  const { error } = await supabase
+    .from('transakcje')
+    .update({
+      data: transakcja.data,
+      typ: transakcja.typ,
+      kwota: Math.abs(transakcja.kwota),
+      kategoria: transakcja.kategoria,
+      podkategoria: transakcja.podkategoria || null,
+      osoba: transakcja.osoba,
+      komentarz: transakcja.komentarz || null,
+    })
+    .eq('id', id)
+    .eq('household_id', HOUSEHOLD_ID);
+
+  if (error) throw error;
+  return { success: true };
+}
+
+export async function deleteTransakcja(id) {
+  const { error } = await supabase
+    .from('transakcje')
+    .delete()
+    .eq('id', id)
+    .eq('household_id', HOUSEHOLD_ID);
+
+  if (error) throw error;
+  return { success: true };
+}
+
+export async function addTransakcjeBatch(transakcje) {
+  const records = transakcje.map(t => {
+    const kwota = typeof t.kwota === 'number' ? t.kwota : parseFloat(t.kwota);
+    return {
+      household_id: HOUSEHOLD_ID,
+      data: t.data,
+      typ: t.typ || (kwota < 0 ? 'Wydatek' : 'Przychód'),
+      kwota: Math.abs(kwota),
+      kategoria: t.kategoria,
+      podkategoria: t.podkategoria || null,
+      osoba: t.osoba || null,
+      komentarz: t.komentarz || t.opis || null,
+    };
+  });
+
+  const { data, error } = await supabase
+    .from('transakcje')
+    .insert(records)
+    .select('id');
+
+  if (error) throw error;
+  return { success: true, count: data.length, ids: data.map(d => d.id) };
+}
+
+// ═══════════════════════════════════════════
+// KATEGORIE
+// ═══════════════════════════════════════════
+
+export async function getKategorie() {
+  const { data, error } = await supabase
+    .from('kategorie')
+    .select('typ, kategoria, podkategoria')
+    .eq('household_id', HOUSEHOLD_ID)
+    .order('typ')
+    .order('kategoria')
+    .order('podkategoria');
+
+  if (error) throw error;
+
+  // Transform flat rows → nested { Wydatek: { cat: [subcats] }, Przychód: {...} }
+  const result = { Wydatek: {}, Przychód: {} };
+  for (const row of data) {
+    if (!result[row.typ]) result[row.typ] = {};
+    if (!result[row.typ][row.kategoria]) result[row.typ][row.kategoria] = [];
+    if (row.podkategoria) {
+      result[row.typ][row.kategoria].push(row.podkategoria);
+    }
+  }
+  return result;
+}
+
+export async function addKategoria(typ, kategoria, podkategoria) {
+  const { error } = await supabase
+    .from('kategorie')
+    .insert({
+      household_id: HOUSEHOLD_ID,
+      typ,
+      kategoria,
+      podkategoria: podkategoria || null,
+    });
+
+  if (error) throw error;
+  return { success: true };
+}
+
+export async function deleteKategoria(typ, kategoria, podkategoria) {
+  let query = supabase
+    .from('kategorie')
+    .delete()
+    .eq('household_id', HOUSEHOLD_ID)
+    .eq('typ', typ)
+    .eq('kategoria', kategoria);
+
+  if (podkategoria) {
+    query = query.eq('podkategoria', podkategoria);
+  }
+
+  const { error } = await query;
+  if (error) throw error;
+  return { success: true };
+}
+
+// ═══════════════════════════════════════════
+// OSOBY
+// ═══════════════════════════════════════════
+
+export async function getOsoby() {
+  const { data, error } = await supabase
+    .from('osoby')
+    .select('nazwa')
+    .eq('household_id', HOUSEHOLD_ID)
+    .order('nazwa');
+
+  if (error) throw error;
+  return data.map(o => o.nazwa);
+}
+
+export async function addOsoba(osoba) {
+  const { error } = await supabase
+    .from('osoby')
+    .insert({
+      household_id: HOUSEHOLD_ID,
+      nazwa: osoba,
+    });
+
+  if (error) throw error;
+  return { success: true };
+}
+
+export async function deleteOsoba(osoba) {
+  const { error } = await supabase
+    .from('osoby')
+    .delete()
+    .eq('household_id', HOUSEHOLD_ID)
+    .eq('nazwa', osoba);
+
+  if (error) throw error;
+  return { success: true };
+}
+
+// ═══════════════════════════════════════════
+// BUDŻETY
+// ═══════════════════════════════════════════
+
+function transformBudget(b, zrodlo) {
+  return {
+    kategoria: b.kategoria,
+    limit: b.limit_kwota,
+    miesiac: b.miesiac,
+    rok: b.rok,
+    osoba: b.osoba || '',
+    zakres: b.zakres,
+    notatki: b.notatki || '',
+    zrodlo,
+    rocznyLimit: null,
+    roczneNotatki: null,
+  };
+}
+
+export async function getBudgets(miesiac, rok) {
+  // Get monthly budgets for the specific month
+  const { data: monthly, error: monthlyError } = await supabase
+    .from('budzety')
+    .select('*')
+    .eq('household_id', HOUSEHOLD_ID)
+    .eq('zakres', 'monthly')
+    .eq('miesiac', miesiac)
+    .eq('rok', rok);
+
+  if (monthlyError) throw monthlyError;
+
+  // Get yearly budgets
+  const { data: yearly, error: yearlyError } = await supabase
+    .from('budzety')
+    .select('*')
+    .eq('household_id', HOUSEHOLD_ID)
+    .eq('zakres', 'yearly')
+    .eq('rok', rok);
+
+  if (yearlyError) throw yearlyError;
+
+  // Resolve hierarchy: monthly overrides yearly
+  const resolved = [];
+  const monthlyByKey = new Map();
+
+  for (const b of monthly) {
+    const key = `${b.kategoria}|${b.osoba || ''}`;
+    monthlyByKey.set(key, b);
+    resolved.push(transformBudget(b, 'monthly'));
+  }
+
+  for (const b of yearly) {
+    const key = `${b.kategoria}|${b.osoba || ''}`;
+    if (!monthlyByKey.has(key)) {
+      resolved.push(transformBudget(b, 'yearly'));
+    } else {
+      // Monthly exists — attach yearly info
+      const existing = resolved.find(r =>
+        r.kategoria === b.kategoria && (r.osoba || '') === (b.osoba || '') && r.zrodlo === 'monthly'
+      );
+      if (existing) {
+        existing.rocznyLimit = b.limit_kwota;
+        existing.roczneNotatki = b.notatki;
+      }
+    }
+  }
+
+  return resolved;
+}
+
+export async function getAllBudgetsForYear(rok) {
+  const { data, error } = await supabase
+    .from('budzety')
+    .select('*')
+    .eq('household_id', HOUSEHOLD_ID)
+    .eq('rok', rok)
+    .order('kategoria')
+    .order('zakres')
+    .order('miesiac');
+
+  if (error) throw error;
+
+  return data.map(b => ({
+    kategoria: b.kategoria,
+    limit: b.limit_kwota,
+    miesiac: b.miesiac,
+    rok: b.rok,
+    osoba: b.osoba || '',
+    zakres: b.zakres,
+    notatki: b.notatki || '',
+  }));
+}
+
+export async function setBudget(budget) {
+  const record = {
+    household_id: HOUSEHOLD_ID,
+    kategoria: budget.kategoria,
+    limit_kwota: budget.limit,
+    rok: Number(budget.rok),
+    osoba: budget.osoba || null,
+    zakres: budget.zakres,
+    notatki: budget.notatki || null,
+    miesiac: budget.zakres === 'monthly' ? Number(budget.miesiac) : null,
+  };
+
+  const { error } = await supabase
+    .from('budzety')
+    .upsert(record, {
+      onConflict: 'household_id,kategoria,osoba,zakres,rok,miesiac',
+    });
+
+  if (error) throw error;
+  return { success: true };
+}
+
+export async function deleteBudget(budget) {
+  let query = supabase
+    .from('budzety')
+    .delete()
+    .eq('household_id', HOUSEHOLD_ID)
+    .eq('kategoria', budget.kategoria)
+    .eq('zakres', budget.zakres)
+    .eq('rok', budget.rok);
+
+  if (budget.osoba) {
+    query = query.eq('osoba', budget.osoba);
+  } else {
+    query = query.is('osoba', null);
+  }
+
+  if (budget.zakres === 'monthly' && budget.miesiac) {
+    query = query.eq('miesiac', budget.miesiac);
+  } else {
+    query = query.is('miesiac', null);
+  }
+
+  const { error } = await query;
+  if (error) throw error;
+  return { success: true };
+}
+
+// ═══════════════════════════════════════════
+// COMBINED DATA FETCH
+// ═══════════════════════════════════════════
+
+export async function getAllData(miesiac, rok) {
+  const [transakcje, kategorie, osoby] = await Promise.all([
+    getTransakcje(miesiac, rok),
+    getKategorie(),
+    getOsoby(),
+  ]);
+
+  return { transakcje, kategorie, osoby };
+}
+
+// ═══════════════════════════════════════════
+// OFFLINE QUEUE OPERATION PROCESSOR
+// ═══════════════════════════════════════════
+
+export async function processOfflineOperation(operation) {
+  const { action, payload } = operation;
+
+  switch (action) {
+    case 'addTransakcja':
+      return addTransakcja(payload.transakcja);
+    case 'updateTransakcja':
+      return updateTransakcja(payload.id, payload.transakcja);
+    case 'deleteTransakcja':
+      return deleteTransakcja(payload.id);
+    default:
+      throw new Error(`Nieznana operacja offline: ${action}`);
+  }
+}

--- a/src/services/offlineQueue.js
+++ b/src/services/offlineQueue.js
@@ -1,3 +1,5 @@
+import { processOfflineOperation } from './api';
+
 const QUEUE_KEY = 'budget_offline_queue';
 
 function getQueue() {
@@ -38,10 +40,10 @@ export function removeFromQueue(operationId) {
 }
 
 /**
- * Process all queued operations sequentially.
+ * Process all queued operations sequentially via Supabase API.
  * Returns { succeeded: number, failed: number, errors: string[] }
  */
-export async function processQueue(authFetch, apiUrl, token) {
+export async function processQueue() {
   const queue = getQueue();
   if (queue.length === 0) return { succeeded: 0, failed: 0, errors: [] };
 
@@ -51,18 +53,11 @@ export async function processQueue(authFetch, apiUrl, token) {
 
   for (const op of queue) {
     try {
-      const res = await authFetch(apiUrl, op.payload, token);
-      const result = await res.json();
-
-      if (result.success === false || result.error) {
-        failed++;
-        errors.push(result.error || `Operacja ${op.action} nie powiodla sie`);
-      } else {
-        succeeded++;
-      }
+      await processOfflineOperation(op);
+      succeeded++;
     } catch (err) {
       failed++;
-      errors.push(`Blad sieci: ${op.action}`);
+      errors.push(err.message || `Operacja ${op.action} nie powiodla sie`);
     }
   }
 


### PR DESCRIPTION
Replace all direct fetch() calls to Google Apps Script with a dedicated Supabase JS SDK service layer. This is Phase 2 of the backend migration.

Changes:
- Add @supabase/supabase-js dependency
- Create src/lib/supabase.js for client initialization
- Create src/services/api.js with all CRUD operations (transakcje, kategorie, osoby, budzety) using Supabase queries
- Refactor App.jsx: remove API_URL, authFetch; use api.* functions
- Refactor Budgets.jsx: remove apiUrl/authToken props; use api.*
- Refactor CSVImport.jsx: remove apiUrl/authToken props, session heartbeat, and token expiry check; use api.addTransakcjeBatch
- Update offlineQueue.js: process queue via api.processOfflineOperation instead of authFetch
- Update .env.example with VITE_SUPABASE_URL, VITE_SUPABASE_ANON_KEY, and VITE_HOUSEHOLD_ID

https://claude.ai/code/session_016Q2g4GwaUeoKfbajcsbqrP