### PR TITLE
Fix month and year fields to have equal width in budget form

### DIFF
--- a/components/Budgets.jsx
+++ b/components/Budgets.jsx
@@ -259,7 +259,7 @@ export default function Budgets({ onClose, kategorie = {}, month, year, budgets 
             </div>
 
             {/* Limit + Okres */}
-            <div className={`grid gap-3 ${form.zakres === 'monthly' ? 'grid-cols-6' : 'grid-cols-2'}`}>
+            <div className={`grid gap-3 ${form.zakres === 'monthly' ? 'grid-cols-5' : 'grid-cols-2'}`}>
               <div className={form.zakres === 'monthly' ? 'col-span-3' : ''}>
                 <label className="block text-sm text-gray-600 mb-2">Limit (PLN)</label>
                 <input


### PR DESCRIPTION
Changed grid from grid-cols-6 to grid-cols-5 so that month (Miesiąc) and year (Rok) fields each take 1/5 of the row width equally, with no unused column. Previously grid-cols-6 left an empty column and made both fields too narrow to display content properly.

https://claude.ai/code/session_01AvEkbqSLhgKHkjbeQvPzcb