### PR TITLE
Fix month select height to match year input height

### DIFF
--- a/components/Budgets.jsx
+++ b/components/Budgets.jsx
@@ -273,12 +273,12 @@ export default function Budgets({ onClose, kategorie = {}, month, year, budgets 
                 />
               </div>
               {form.zakres === 'monthly' && (
-                <div>
+                <div className="flex flex-col">
                   <label className="block text-sm text-gray-600 mb-2">Miesiąc</label>
                   <select
                     value={form.miesiac}
                     onChange={e => setForm(prev => ({ ...prev, miesiac: Number(e.target.value) }))}
-                    className="w-full rounded-xl border border-gray-200 px-4 py-3 focus:border-indigo-500 focus:ring-2 focus:ring-indigo-200 outline-none transition-all bg-white"
+                    className="w-full flex-1 rounded-xl border border-gray-200 px-4 py-3 focus:border-indigo-500 focus:ring-2 focus:ring-indigo-200 outline-none transition-all bg-white"
                   >
                     {Array.from({ length: 12 }, (_, i) => i + 1).map(m => (
                       <option key={m} value={m}>{MONTH_NAMES[m]}</option>


### PR DESCRIPTION
The <select> element for month rendered shorter than the <input> for year despite having the same padding classes. Added flex-col to the wrapper div and flex-1 to the select so it stretches to match the height of sibling input fields in the same grid row.

https://claude.ai/code/session_01AvEkbqSLhgKHkjbeQvPzcb