### PR TITLE
refactor: usprawnienia z code review — logger, memoizacja, drobne poprawki

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useCallback, useRef } from 'react';
+import React, { useState, useEffect, useCallback, useRef, useMemo } from 'react';
 import CategoryCharts from '/components/CategoryCharts';
 import Budgets from '/components/Budgets';
 import CSVImport from '/components/CSVImport';
@@ -11,6 +11,7 @@ import { useOffline } from './hooks/useOffline';
 import { addToQueue, getQueuedOperations, processQueue } from './services/offlineQueue';
 import { supabase } from './lib/supabase';
 import * as api from './services/api';
+import { logger } from './utils/logger';
 
 // Pomocnicze funkcje
 const formatCurrency = (amount) => {
@@ -553,7 +554,7 @@ const SettingsPanel = ({ onClose, kategorie, osoby, transakcje, onKategorieChang
       }
     } catch (err) {
       showError('Błąd połączenia z serwerem');
-      console.error(err);
+      logger.error('App', err);
     } finally {
       setIsProcessing(false);
     }
@@ -601,7 +602,7 @@ const SettingsPanel = ({ onClose, kategorie, osoby, transakcje, onKategorieChang
       }
     } catch (err) {
       showError('Błąd połączenia z serwerem');
-      console.error(err);
+      logger.error('App', err);
     } finally {
       setIsProcessing(false);
     }
@@ -633,7 +634,7 @@ const SettingsPanel = ({ onClose, kategorie, osoby, transakcje, onKategorieChang
       }
     } catch (err) {
       showError('Błąd połączenia z serwerem');
-      console.error(err);
+      logger.error('App', err);
     } finally {
       setIsProcessing(false);
     }
@@ -674,7 +675,7 @@ const SettingsPanel = ({ onClose, kategorie, osoby, transakcje, onKategorieChang
       }
     } catch (err) {
       showError('Błąd połączenia z serwerem');
-      console.error(err);
+      logger.error('App', err);
     } finally {
       setIsProcessing(false);
     }
@@ -1082,12 +1083,12 @@ export default function BudgetApp() {
         const bData = await api.getBudgets(currentPeriod.month, currentPeriod.year);
         setBudgets(Array.isArray(bData) ? bData : []);
       } catch (err) {
-        console.warn('Nie udało się pobrać budżetów', err);
+        logger.warn('App', 'Nie udało się pobrać budżetów', err);
       }
       
     } catch (err) {
       setError('Nie udało się pobrać danych. Sprawdź połączenie i odśwież stronę.');
-      console.error(err);
+      logger.error('App', err);
     } finally {
       setIsLoading(false);
     }
@@ -1244,7 +1245,7 @@ export default function BudgetApp() {
       }
     } catch (err) {
       addToast('Błąd podczas zapisywania', 'error');
-      console.error(err);
+      logger.error('App', err);
     } finally {
       setIsSaving(false);
     }
@@ -1285,7 +1286,7 @@ export default function BudgetApp() {
       }
     } catch (err) {
       addToast('Błąd podczas aktualizacji', 'error');
-      console.error(err);
+      logger.error('App', err);
     } finally {
       setIsSaving(false);
     }
@@ -1332,7 +1333,7 @@ export default function BudgetApp() {
       }
     } catch (err) {
       addToast('Błąd podczas usuwania', 'error');
-      console.error(err);
+      logger.error('App', err);
     }
   };
   
@@ -1363,20 +1364,22 @@ export default function BudgetApp() {
     setOsoby(noweOsoby);
   };
   
-  // Obliczenia
-  const przychody = transakcje
-    .filter(t => t.typ === 'Przychód')
-    .reduce((sum, t) => sum + Number(t.kwota), 0);
-  
-  const wydatki = transakcje
-    .filter(t => t.typ === 'Wydatek')
-    .reduce((sum, t) => sum + Number(t.kwota), 0);
-  
-  const bilans = przychody - wydatki;
-  
+  // Obliczenia — memoizowane aby uniknąć przeliczania na każdym renderze.
+  const { przychody, wydatki, bilans } = useMemo(() => {
+    let p = 0;
+    let w = 0;
+    for (const t of transakcje) {
+      const kwota = Number(t.kwota);
+      if (t.typ === 'Przychód') p += kwota;
+      else if (t.typ === 'Wydatek') w += kwota;
+    }
+    return { przychody: p, wydatki: w, bilans: p - w };
+  }, [transakcje]);
+
   // Sortowanie transakcji (najnowsze pierwsze)
-  const sortedTransakcje = [...transakcje].sort((a, b) => 
-    new Date(b.data) - new Date(a.data)
+  const sortedTransakcje = useMemo(
+    () => [...transakcje].sort((a, b) => new Date(b.data) - new Date(a.data)),
+    [transakcje]
   );
   
   // Auth gate: show login page if not authenticated
@@ -1695,7 +1698,7 @@ export default function BudgetApp() {
               const bData = await api.getBudgets(currentPeriod.month, currentPeriod.year);
               setBudgets(Array.isArray(bData) ? bData : []);
             } catch (err) {
-              console.warn('Nie udało się odświeżyć budżetów', err);
+              logger.warn('App', 'Nie udało się odświeżyć budżetów', err);
             }
           }}
         />

--- a/src/components/LoginPage.jsx
+++ b/src/components/LoginPage.jsx
@@ -42,8 +42,7 @@ export default function LoginPage() {
 
     if (!window.google?.accounts?.id) return;
 
-    // Clear previous button content before re-rendering
-    buttonRef.current.innerHTML = '';
+    buttonRef.current.replaceChildren();
     window.google.accounts.id.renderButton(buttonRef.current, {
       type: 'standard',
       theme: 'outline',

--- a/src/contexts/AuthContext.jsx
+++ b/src/contexts/AuthContext.jsx
@@ -1,11 +1,15 @@
 import React, { createContext, useContext, useState, useEffect, useCallback, useRef } from 'react';
+import { logger } from '../utils/logger';
 
 const AuthContext = createContext(null);
 
 const GOOGLE_CLIENT_ID = import.meta.env.VITE_GOOGLE_CLIENT_ID;
 const GIS_TIMEOUT_MS = 10000;
 
-// Decode JWT payload without external libraries
+// Decode JWT payload without external libraries.
+// Trust boundary: we do NOT verify the signature here. This is safe because the
+// token is only used client-side for UI state (display name, expiry check). Any
+// server-side call that relies on identity must re-verify the token with Google.
 function decodeJwtPayload(token) {
   try {
     const base64Url = token.split('.')[1];
@@ -150,12 +154,11 @@ export function AuthProvider({ children }) {
       if (hasValidToken) {
         window.google.accounts.id.prompt((notification) => {
           if (notification.isNotDisplayed() || notification.isSkippedMoment()) {
-            if (import.meta.env.DEV) {
-              console.warn(
-                '[Auth] One Tap not shown:',
-                notification.getNotDisplayedReason?.() || notification.getSkippedReason?.()
-              );
-            }
+            logger.debug(
+              'Auth',
+              'One Tap not shown:',
+              notification.getNotDisplayedReason?.() || notification.getSkippedReason?.()
+            );
           }
         });
       }

--- a/src/services/api.js
+++ b/src/services/api.js
@@ -1,4 +1,5 @@
 import { supabase } from '../lib/supabase';
+import { logger } from '../utils/logger';
 
 // Fallback dla backward compatibility (dla development bez auth)
 const FALLBACK_HOUSEHOLD_ID = import.meta.env.VITE_HOUSEHOLD_ID;
@@ -80,7 +81,7 @@ async function getHouseholdId() {
     const profile = await getUserProfile();
     return profile.household_id;
   } catch (err) {
-    console.warn('Nie udało się pobrać household_id z profilu, używam fallback', err);
+    logger.warn('api', 'Nie udało się pobrać household_id z profilu, używam fallback', err);
     if (FALLBACK_HOUSEHOLD_ID) {
       return FALLBACK_HOUSEHOLD_ID;
     }

--- a/src/services/categoryAI.js
+++ b/src/services/categoryAI.js
@@ -1,5 +1,6 @@
 import { supabase } from '../lib/supabase';
 import { getUserProfile } from './api';
+import { logger } from '../utils/logger';
 
 // VITE_AI_ENABLED to tylko flaga (true/false) — klucz OpenAI pozostaje
 // wyłącznie po stronie serwera w zmiennej OPENAI_API_KEY (bez prefiksu VITE_).
@@ -52,12 +53,12 @@ export async function saveCategoryRule(description, kategoria, podkategoria, sou
     });
 
     if (error) {
-      console.error('saveCategoryRule insert error:', error);
+      logger.error('categoryAI', 'saveCategoryRule insert error:', error);
       return null;
     }
     return true;
   } catch (err) {
-    console.error('saveCategoryRule failed:', err);
+    logger.error('categoryAI', 'saveCategoryRule failed:', err);
     return null;
   }
 }
@@ -91,10 +92,10 @@ export async function saveCategoryRulesBatch(transactions) {
       }));
 
       const { error } = await supabase.from('category_rules').insert(records);
-      if (error) console.error('saveCategoryRulesBatch chunk error:', error);
+      if (error) logger.error('categoryAI', 'saveCategoryRulesBatch chunk error:', error);
     }
   } catch (err) {
-    console.error('saveCategoryRulesBatch failed:', err);
+    logger.error('categoryAI', 'saveCategoryRulesBatch failed:', err);
   }
 }
 
@@ -137,7 +138,7 @@ export async function categorizeWithAI(descriptions) {
     indexed.forEach(({ i }, j) => { output[i] = matchResults[j]; });
     return output;
   } catch (err) {
-    console.error('categorizeWithAI failed:', err);
+    logger.error('categoryAI', 'categorizeWithAI failed:', err);
     return descriptions.map(() => null);
   }
 }

--- a/src/services/offlineQueue.js
+++ b/src/services/offlineQueue.js
@@ -1,4 +1,5 @@
 import { processOfflineOperation } from './api';
+import { logger } from '../utils/logger';
 
 const QUEUE_KEY = 'budget_offline_queue';
 const VALID_ACTIONS = ['addTransakcja', 'updateTransakcja', 'deleteTransakcja'];
@@ -16,7 +17,7 @@ function saveQueue(queue) {
     localStorage.setItem(QUEUE_KEY, JSON.stringify(queue));
   } catch (err) {
     if (err?.name === 'QuotaExceededError' || err?.code === 22) {
-      console.error('[OfflineQueue] localStorage pełne — nie można zapisać kolejki offline', err);
+      logger.error('OfflineQueue', 'localStorage pełne — nie można zapisać kolejki offline', err);
     }
     throw err;
   }

--- a/src/utils/logger.js
+++ b/src/utils/logger.js
@@ -1,0 +1,23 @@
+// Thin logger wrapper. Allows future forwarding to telemetry and silences
+// debug/info noise in production builds while keeping errors/warnings visible.
+
+const isDev = import.meta.env?.DEV ?? false;
+
+function prefix(scope) {
+  return scope ? [`[${scope}]`] : [];
+}
+
+export const logger = {
+  error(scope, ...args) {
+    console.error(...prefix(scope), ...args);
+  },
+  warn(scope, ...args) {
+    console.warn(...prefix(scope), ...args);
+  },
+  info(scope, ...args) {
+    if (isDev) console.info(...prefix(scope), ...args);
+  },
+  debug(scope, ...args) {
+    if (isDev) console.debug(...prefix(scope), ...args);
+  },
+};


### PR DESCRIPTION
- dodaj cienki wrapper logger (src/utils/logger.js) z prefiksem scope;
  debug/info wyciszane w produkcji, error/warn zawsze widoczne
- zastąp wszystkie console.error/warn w App/AuthContext/services/offlineQueue
  wywołaniami logger.{error,warn,debug} ze spójnym scope
- LoginPage: użyj replaceChildren() zamiast innerHTML='' do czyszczenia
  kontenera przycisku Google (bezpieczniejsze, czytelniejsze)
- AuthContext: dodaj komentarz o granicy zaufania przy decodeJwtPayload
  (brak weryfikacji podpisu — tylko UI state)
- App.jsx: memoizuj sumy przychody/wydatki/bilans (jedna pętla zamiast
  dwóch filter+reduce) oraz sortedTransakcje przez useMemo

Testy: 205/205 przechodzi. Build OK.

https://claude.ai/code/session_01RA2m3RcsnnebQeViwDZyee