### PR TITLE
refactor: rozbij YearlySummary na zakładki + testy hooków

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -12,28 +12,22 @@ import { addToQueue, getQueuedOperations, processQueue } from './services/offlin
 import { supabase } from './lib/supabase';
 import * as api from './services/api';
 import { logger } from './utils/logger';
+import {
+  formatCurrency,
+  getMonthName,
+  getCurrentMonth,
+  calculateIncome,
+  calculateExpenses,
+  sortTransactionsByDate,
+  changeMonth as computeMonthChange,
+} from './utils/calculations';
 
-// Pomocnicze funkcje
-const formatCurrency = (amount) => {
-  return new Intl.NumberFormat('pl-PL', {
-    style: 'currency',
-    currency: 'PLN'
-  }).format(amount);
-};
-
+// Data format specyficzny dla UI (notacja kropkowa pl-PL, np. "13.02.2026").
+// Różni się od utils/calculations.formatDate (slashes) używanego w testach
+// i kontekstach nie-UI — dlatego celowo nie konsolidujemy.
 const formatDate = (dateString) => {
   const date = new Date(dateString);
   return date.toLocaleDateString('pl-PL', { day: '2-digit', month: '2-digit', year: 'numeric' });
-};
-
-const getCurrentMonth = () => {
-  const now = new Date();
-  return { month: now.getMonth() + 1, year: now.getFullYear() };
-};
-
-const getMonthName = (month, year) => {
-  const date = new Date(year, month - 1);
-  return date.toLocaleDateString('pl-PL', { month: 'long', year: 'numeric' });
 };
 
 // Ikony SVG
@@ -1339,20 +1333,7 @@ export default function BudgetApp() {
   
   // Nawigacja miesięcy
   const changeMonth = (delta) => {
-    setCurrentPeriod(prev => {
-      let newMonth = prev.month + delta;
-      let newYear = prev.year;
-      
-      if (newMonth > 12) {
-        newMonth = 1;
-        newYear++;
-      } else if (newMonth < 1) {
-        newMonth = 12;
-        newYear--;
-      }
-      
-      return { month: newMonth, year: newYear };
-    });
+    setCurrentPeriod(prev => computeMonthChange(prev.month, prev.year, delta));
   };
   
   // Callbacki dla ustawień — aktualizują stan
@@ -1364,23 +1345,12 @@ export default function BudgetApp() {
     setOsoby(noweOsoby);
   };
   
-  // Obliczenia — memoizowane aby uniknąć przeliczania na każdym renderze.
-  const { przychody, wydatki, bilans } = useMemo(() => {
-    let p = 0;
-    let w = 0;
-    for (const t of transakcje) {
-      const kwota = Number(t.kwota);
-      if (t.typ === 'Przychód') p += kwota;
-      else if (t.typ === 'Wydatek') w += kwota;
-    }
-    return { przychody: p, wydatki: w, bilans: p - w };
-  }, [transakcje]);
+  // Obliczenia — memoizowane, korzystają z pure helperów z utils/calculations.
+  const przychody = useMemo(() => calculateIncome(transakcje), [transakcje]);
+  const wydatki = useMemo(() => calculateExpenses(transakcje), [transakcje]);
+  const bilans = przychody - wydatki;
 
-  // Sortowanie transakcji (najnowsze pierwsze)
-  const sortedTransakcje = useMemo(
-    () => [...transakcje].sort((a, b) => new Date(b.data) - new Date(a.data)),
-    [transakcje]
-  );
+  const sortedTransakcje = useMemo(() => sortTransactionsByDate(transakcje), [transakcje]);
   
   // Auth gate: show login page if not authenticated
   if (authLoading) {

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -8,6 +8,7 @@ import YearlySummary from './components/YearlySummary';
 import { useAuth } from './contexts/AuthContext';
 import { useToast } from './contexts/ToastContext';
 import { useOffline } from './hooks/useOffline';
+import { useBudgets } from './hooks/useBudgets';
 import { addToQueue, getQueuedOperations, processQueue } from './services/offlineQueue';
 import { supabase } from './lib/supabase';
 import * as api from './services/api';
@@ -1001,7 +1002,6 @@ export default function BudgetApp() {
   const [osoby, setOsoby] = useState([]);
   const [isLoading, setIsLoading] = useState(true);
   const [isSaving, setIsSaving] = useState(false);
-  const [budgets, setBudgets] = useState([]);
   const [showBudgets, setShowBudgets] = useState(false);
   const [showForm, setShowForm] = useState(false);
   const [showSettings, setShowSettings] = useState(false);
@@ -1018,7 +1018,14 @@ export default function BudgetApp() {
   const [availableYears, setAvailableYears] = useState([new Date().getFullYear()]);
   const [showHint, setShowHint] = useState(() => !localStorage.getItem('yearlyViewHintSeen'));
   const [pulseActive, setPulseActive] = useState(() => !localStorage.getItem('yearlyViewHintSeen'));
-  
+
+  // Budżety dla bieżącego okresu — własny hook, niezależny od fetchData
+  const { budgets, refresh: refreshBudgets } = useBudgets({
+    month: currentPeriod.month,
+    year: currentPeriod.year,
+    enabled: isAuthenticated && !isOffline,
+  });
+
   // Fetch available years for yearly view
   useEffect(() => {
     if (!isAuthenticated || isOffline) return;
@@ -1071,15 +1078,7 @@ export default function BudgetApp() {
       setTransakcje(noweTransakcje);
       setKategorie(noweKategorie);
       setOsoby(noweOsoby);
-      
-      // Pobierz budżety dla okresu
-      try {
-        const bData = await api.getBudgets(currentPeriod.month, currentPeriod.year);
-        setBudgets(Array.isArray(bData) ? bData : []);
-      } catch (err) {
-        logger.warn('App', 'Nie udało się pobrać budżetów', err);
-      }
-      
+
     } catch (err) {
       setError('Nie udało się pobrać danych. Sprawdź połączenie i odśwież stronę.');
       logger.error('App', err);
@@ -1663,14 +1662,7 @@ export default function BudgetApp() {
           year={currentPeriod.year}
           budgets={budgets}
           osoby={osoby}
-          onSaved={async () => {
-            try {
-              const bData = await api.getBudgets(currentPeriod.month, currentPeriod.year);
-              setBudgets(Array.isArray(bData) ? bData : []);
-            } catch (err) {
-              logger.warn('App', 'Nie udało się odświeżyć budżetów', err);
-            }
-          }}
+          onSaved={refreshBudgets}
         />
       )}
 

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -9,6 +9,7 @@ import { useAuth } from './contexts/AuthContext';
 import { useToast } from './contexts/ToastContext';
 import { useOffline } from './hooks/useOffline';
 import { useBudgets } from './hooks/useBudgets';
+import { useAvailableYears } from './hooks/useAvailableYears';
 import { addToQueue, getQueuedOperations, processQueue } from './services/offlineQueue';
 import { supabase } from './lib/supabase';
 import * as api from './services/api';
@@ -1015,7 +1016,6 @@ export default function BudgetApp() {
   // Yearly summary view state
   const [activeView, setActiveView] = useState('monthly');
   const [selectedYear, setSelectedYear] = useState(() => new Date().getFullYear());
-  const [availableYears, setAvailableYears] = useState([new Date().getFullYear()]);
   const [showHint, setShowHint] = useState(() => !localStorage.getItem('yearlyViewHintSeen'));
   const [pulseActive, setPulseActive] = useState(() => !localStorage.getItem('yearlyViewHintSeen'));
 
@@ -1026,13 +1026,7 @@ export default function BudgetApp() {
     enabled: isAuthenticated && !isOffline,
   });
 
-  // Fetch available years for yearly view
-  useEffect(() => {
-    if (!isAuthenticated || isOffline) return;
-    api.getAvailableYears().then(years => {
-      setAvailableYears(years);
-    }).catch(() => {});
-  }, [isAuthenticated, isOffline]);
+  const availableYears = useAvailableYears({ enabled: isAuthenticated && !isOffline });
 
   // Auto-stop pulse animation after 5 seconds
   useEffect(() => {

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -11,7 +11,8 @@ import { useOffline } from './hooks/useOffline';
 import { useBudgets } from './hooks/useBudgets';
 import { useAvailableYears } from './hooks/useAvailableYears';
 import { useYearlyViewHint } from './hooks/useYearlyViewHint';
-import { addToQueue, getQueuedOperations, processQueue } from './services/offlineQueue';
+import { usePendingOperations } from './hooks/usePendingOperations';
+import { addToQueue } from './services/offlineQueue';
 import { supabase } from './lib/supabase';
 import * as api from './services/api';
 import { logger } from './utils/logger';
@@ -1010,9 +1011,6 @@ export default function BudgetApp() {
   const [showCSVImport, setShowCSVImport] = useState(false);
   const [editingTransaction, setEditingTransaction] = useState(null);
   const [error, setError] = useState(null);
-  const [isSyncing, setIsSyncing] = useState(false);
-  const [pendingCount, setPendingCount] = useState(() => getQueuedOperations().length);
-  const wasOfflineRef = useRef(isOffline);
 
   // Yearly summary view state
   const [activeView, setActiveView] = useState('monthly');
@@ -1076,35 +1074,12 @@ export default function BudgetApp() {
     fetchData();
   }, [fetchData]);
 
-  // Sync queued operations when coming back online
-  useEffect(() => {
-    if (wasOfflineRef.current && !isOffline) {
-      const syncQueue = async () => {
-        const queue = getQueuedOperations();
-        if (queue.length === 0) {
-          wasOfflineRef.current = false;
-          return;
-        }
-        setIsSyncing(true);
-        try {
-          const result = await processQueue();
-          if (result.succeeded > 0) {
-            addToast(`Zsynchronizowano ${result.succeeded} ${result.succeeded === 1 ? 'operację' : 'operacji'}`);
-          }
-          if (result.failed > 0) {
-            addToast(`Nie udało się zsynchronizować ${result.failed} operacji`, 'error');
-          }
-          setPendingCount(0);
-          // Refresh data from server after sync
-          await fetchData(false);
-        } finally {
-          setIsSyncing(false);
-        }
-      };
-      syncQueue();
-    }
-    wasOfflineRef.current = isOffline;
-  }, [isOffline, fetchData, addToast]);
+  // Offline queue: licznik + auto-sync przy powrocie online
+  const { pendingCount, isSyncing, refreshPendingCount } = usePendingOperations({
+    isOffline,
+    onSynced: () => fetchData(false),
+    addToast,
+  });
 
   // Real-time subscriptions — nasłuchuj zmian w Supabase
   useEffect(() => {
@@ -1202,7 +1177,7 @@ export default function BudgetApp() {
       setTransakcje(noweTransakcje);
 
       addToQueue({ action: 'addTransakcja', payload: { action: 'addTransakcja', transakcja } });
-      setPendingCount(getQueuedOperations().length);
+      refreshPendingCount();
 
       setShowForm(false);
       addToast('Transakcja zapisana offline — zsynchronizuje się po połączeniu');
@@ -1241,7 +1216,7 @@ export default function BudgetApp() {
         action: 'updateTransakcja',
         payload: { action: 'updateTransakcja', id: editingTransaction.id, transakcja },
       });
-      setPendingCount(getQueuedOperations().length);
+      refreshPendingCount();
 
       setEditingTransaction(null);
       setShowForm(false);
@@ -1293,7 +1268,7 @@ export default function BudgetApp() {
       // Don't queue delete for temp (not-yet-synced) transactions
       if (!String(id).startsWith('temp_')) {
         addToQueue({ action: 'deleteTransakcja', payload: { action: 'deleteTransakcja', id } });
-        setPendingCount(getQueuedOperations().length);
+        refreshPendingCount();
       }
 
       addToast('Usunięcie zapisane offline — zsynchronizuje się po połączeniu');

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -12,6 +12,7 @@ import { useBudgets } from './hooks/useBudgets';
 import { useAvailableYears } from './hooks/useAvailableYears';
 import { useYearlyViewHint } from './hooks/useYearlyViewHint';
 import { usePendingOperations } from './hooks/usePendingOperations';
+import { useMonthlyData } from './hooks/useMonthlyData';
 import { addToQueue } from './services/offlineQueue';
 import { supabase } from './lib/supabase';
 import * as api from './services/api';
@@ -1000,17 +1001,30 @@ export default function BudgetApp() {
   const { isOffline } = useOffline();
 
   const [currentPeriod, setCurrentPeriod] = useState(getCurrentMonth());
-  const [transakcje, setTransakcje] = useState([]);
-  const [kategorie, setKategorie] = useState({ Wydatek: {}, Przychód: {} });
-  const [osoby, setOsoby] = useState([]);
-  const [isLoading, setIsLoading] = useState(true);
   const [isSaving, setIsSaving] = useState(false);
   const [showBudgets, setShowBudgets] = useState(false);
   const [showForm, setShowForm] = useState(false);
   const [showSettings, setShowSettings] = useState(false);
   const [showCSVImport, setShowCSVImport] = useState(false);
   const [editingTransaction, setEditingTransaction] = useState(null);
-  const [error, setError] = useState(null);
+
+  // Dane miesiąca — transakcje, kategorie, osoby + fetch z isLoading/error.
+  // Setery zwracane do optymistycznych aktualizacji i callbacków ustawień.
+  const {
+    transakcje,
+    kategorie,
+    osoby,
+    isLoading,
+    error,
+    setTransakcje,
+    setKategorie,
+    setOsoby,
+    setError,
+    refresh: fetchData,
+  } = useMonthlyData({
+    month: currentPeriod.month,
+    year: currentPeriod.year,
+  });
 
   // Yearly summary view state
   const [activeView, setActiveView] = useState('monthly');
@@ -1032,47 +1046,6 @@ export default function BudgetApp() {
     setActiveView(v => v === 'monthly' ? 'yearly' : 'monthly');
     if (showHint) dismissHint();
   };
-
-  // Pobierz wszystkie dane
-  const fetchData = useCallback(async (showLoadingSpinner = true) => {
-    if (showLoadingSpinner) {
-      setIsLoading(true);
-    }
-    
-    setError(null);
-
-    // If offline, just show cached data if available — don't attempt network fetch
-    if (!navigator.onLine) {
-      setError('Brak połączenia z internetem.');
-      setIsLoading(false);
-      return;
-    }
-
-    // Pobierz świeże dane
-    try {
-      const data = await api.getAllData(currentPeriod.month, currentPeriod.year);
-
-      // Aktualizuj stan
-      const noweTransakcje = Array.isArray(data.transakcje) ? data.transakcje : [];
-      const noweKategorie = data.kategorie || { Wydatek: {}, Przychód: {} };
-      const noweOsoby = Array.isArray(data.osoby) ? data.osoby : [];
-
-      setTransakcje(noweTransakcje);
-      setKategorie(noweKategorie);
-      setOsoby(noweOsoby);
-
-    } catch (err) {
-      setError('Nie udało się pobrać danych. Sprawdź połączenie i odśwież stronę.');
-      logger.error('App', err);
-    } finally {
-      setIsLoading(false);
-    }
-  }, [currentPeriod]);
-
-  // Ładuj dane przy starcie i zmianie miesiąca
-  useEffect(() => {
-    fetchData();
-  }, [fetchData]);
 
   // Offline queue: licznik + auto-sync przy powrocie online
   const { pendingCount, isSyncing, refreshPendingCount } = usePendingOperations({

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -10,6 +10,7 @@ import { useToast } from './contexts/ToastContext';
 import { useOffline } from './hooks/useOffline';
 import { useBudgets } from './hooks/useBudgets';
 import { useAvailableYears } from './hooks/useAvailableYears';
+import { useYearlyViewHint } from './hooks/useYearlyViewHint';
 import { addToQueue, getQueuedOperations, processQueue } from './services/offlineQueue';
 import { supabase } from './lib/supabase';
 import * as api from './services/api';
@@ -1016,8 +1017,7 @@ export default function BudgetApp() {
   // Yearly summary view state
   const [activeView, setActiveView] = useState('monthly');
   const [selectedYear, setSelectedYear] = useState(() => new Date().getFullYear());
-  const [showHint, setShowHint] = useState(() => !localStorage.getItem('yearlyViewHintSeen'));
-  const [pulseActive, setPulseActive] = useState(() => !localStorage.getItem('yearlyViewHintSeen'));
+  const { showHint, pulseActive, dismissHint } = useYearlyViewHint();
 
   // Budżety dla bieżącego okresu — własny hook, niezależny od fetchData
   const { budgets, refresh: refreshBudgets } = useBudgets({
@@ -1029,20 +1029,10 @@ export default function BudgetApp() {
   const availableYears = useAvailableYears({ enabled: isAuthenticated && !isOffline });
 
   // Auto-stop pulse animation after 5 seconds
-  useEffect(() => {
-    if (!pulseActive) return;
-    const timer = setTimeout(() => setPulseActive(false), 5000);
-    return () => clearTimeout(timer);
-  }, [pulseActive]);
-
   // Handle yearly view toggle
   const handleToggleView = () => {
     setActiveView(v => v === 'monthly' ? 'yearly' : 'monthly');
-    if (showHint) {
-      setShowHint(false);
-      setPulseActive(false);
-      localStorage.setItem('yearlyViewHintSeen', 'true');
-    }
+    if (showHint) dismissHint();
   };
 
   // Pobierz wszystkie dane

--- a/src/components/TransactionItem.jsx
+++ b/src/components/TransactionItem.jsx
@@ -1,4 +1,15 @@
 import React from 'react';
+import { formatCurrency } from '../utils/calculations';
+
+// Format daty specyficzny dla UI (kropki pl-PL, np. "13.02.2026").
+const formatDate = (dateString) => {
+  const date = new Date(dateString);
+  return date.toLocaleDateString('pl-PL', {
+    day: '2-digit',
+    month: '2-digit',
+    year: 'numeric',
+  });
+};
 
 /**
  * Komponent wyświetlający pojedynczą transakcję
@@ -23,22 +34,6 @@ export default function TransactionItem({
   
   const isExpense = typ === 'Wydatek';
   const isIncome = typ === 'Przychód';
-
-  const formatCurrency = (amount) => {
-    return new Intl.NumberFormat('pl-PL', {
-      style: 'currency',
-      currency: 'PLN'
-    }).format(amount);
-  };
-
-  const formatDate = (dateString) => {
-    const date = new Date(dateString);
-    return date.toLocaleDateString('pl-PL', {
-      day: '2-digit',
-      month: '2-digit',
-      year: 'numeric'
-    });
-  };
 
   const colorClass = isExpense ? 'text-rose-600' : 'text-emerald-600';
   const signSymbol = isExpense ? '-' : '+';

--- a/src/components/YearlySummary.jsx
+++ b/src/components/YearlySummary.jsx
@@ -1,188 +1,21 @@
 import { useState } from 'react';
-import {
-  BarChart, Bar, XAxis, YAxis, CartesianGrid, Tooltip, ResponsiveContainer,
-  AreaChart, Area, PieChart, Pie, Cell, Legend,
-} from 'recharts';
-import {
-  formatCurrency,
-  MONTHS_PL_SHORT,
-} from '../utils/calculations';
 import { useYearlyData } from '../hooks/useYearlyData';
+import { LoaderIcon } from './yearly/primitives';
+import OverviewTab from './yearly/OverviewTab';
+import CompareTab from './yearly/CompareTab';
+import PersonsTab from './yearly/PersonsTab';
 
-// ============================================
-// COLOR PALETTE (reuse from CategoryCharts)
-// ============================================
-const CATEGORY_COLORS = [
-  '#6366f1', '#f43f5e', '#10b981', '#f59e0b', '#8b5cf6',
-  '#06b6d4', '#ec4899', '#84cc16', '#ef4444', '#14b8a6',
-  '#a855f7', '#f97316', '#3b82f6', '#eab308', '#22d3ee',
+const TABS = [
+  { id: 'overview', label: 'Przegląd' },
+  { id: 'compare', label: 'Porównanie lat' },
+  { id: 'persons', label: 'Osoby' },
 ];
 
-// ============================================
-// INLINE SVG ICONS
-// ============================================
-const TrendUpIcon = () => (
-  <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-    <polyline points="23 6 13.5 15.5 8.5 10.5 1 18" /><polyline points="17 6 23 6 23 12" />
-  </svg>
-);
-const TrendDownIcon = () => (
-  <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-    <polyline points="23 18 13.5 8.5 8.5 13.5 1 6" /><polyline points="17 18 23 18 23 12" />
-  </svg>
-);
-const WalletIcon = () => (
-  <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-    <path d="M21 12V7H5a2 2 0 0 1 0-4h14v4" /><path d="M3 5v14a2 2 0 0 0 2 2h16v-5" /><path d="M18 12a2 2 0 0 0 0 4h4v-4Z" />
-  </svg>
-);
-const PiggyIcon = () => (
-  <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-    <path d="M19 5c-1.5 0-2.8 1.4-3 2-3.5-1.5-11-.3-11 5 0 1.8 0 3 2 4.5V20h4v-2h3v2h4v-4c1-.5 1.7-1 2-2h2v-4h-2c0-1-.5-1.5-1-2" />
-    <path d="M2 9.5a.5.5 0 1 0 1 0 .5.5 0 0 0-1 0" />
-  </svg>
-);
-const LoaderIcon = () => (
-  <svg className="animate-spin" xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-    <path d="M21 12a9 9 0 1 1-6.219-8.56" />
-  </svg>
-);
-const CalendarSearchIcon = () => (
-  <svg xmlns="http://www.w3.org/2000/svg" width="48" height="48" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round">
-    <rect x="3" y="4" width="18" height="18" rx="2" ry="2" /><line x1="16" y1="2" x2="16" y2="6" /><line x1="8" y1="2" x2="8" y2="6" /><line x1="3" y1="10" x2="21" y2="10" />
-  </svg>
-);
-const UserIcon = () => (
-  <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-    <path d="M20 21v-2a4 4 0 0 0-4-4H8a4 4 0 0 0-4 4v2" /><circle cx="12" cy="7" r="4" />
-  </svg>
-);
-
-// ============================================
-// CUSTOM TOOLTIPS
-// ============================================
-const MonthlyBarTooltip = ({ active, payload, label }) => {
-  if (!active || !payload?.length) return null;
-  return (
-    <div className="bg-white rounded-xl shadow-lg border border-gray-100 px-4 py-3">
-      <p className="font-semibold text-gray-800 text-sm mb-1">{label}</p>
-      {payload.map((entry, idx) => (
-        <p key={idx} className="text-sm" style={{ color: entry.color }}>
-          {entry.name}: {formatCurrency(entry.value)}
-        </p>
-      ))}
-    </div>
-  );
-};
-
-const AreaTooltip = ({ active, payload, label }) => {
-  if (!active || !payload?.length) return null;
-  return (
-    <div className="bg-white rounded-xl shadow-lg border border-gray-100 px-4 py-3">
-      <p className="font-semibold text-gray-800 text-sm">{label}</p>
-      <p className="text-indigo-600 text-sm">{formatCurrency(payload[0].value)}</p>
-    </div>
-  );
-};
-
-const PieTooltip = ({ active, payload }) => {
-  if (!active || !payload?.length) return null;
-  const d = payload[0];
-  return (
-    <div className="bg-white rounded-xl shadow-lg border border-gray-100 px-4 py-3">
-      <p className="font-semibold text-gray-800 text-sm">{d.name}</p>
-      <p className="text-gray-600 text-sm">{formatCurrency(d.value)}</p>
-    </div>
-  );
-};
-
-const renderPieLabel = ({ cx, cy, midAngle, innerRadius, outerRadius, percent }) => {
-  if (percent < 0.05) return null;
-  const RADIAN = Math.PI / 180;
-  const radius = innerRadius + (outerRadius - innerRadius) * 0.5;
-  const x = cx + radius * Math.cos(-midAngle * RADIAN);
-  const y = cy + radius * Math.sin(-midAngle * RADIAN);
-  return (
-    <text x={x} y={y} fill="white" textAnchor="middle" dominantBaseline="central"
-      className="text-xs font-semibold" style={{ textShadow: '0 1px 2px rgba(0,0,0,0.3)' }}>
-      {(percent * 100).toFixed(0)}%
-    </text>
-  );
-};
-
-const CustomLegend = ({ payload }) => {
-  if (!payload) return null;
-  return (
-    <div className="flex flex-wrap justify-center gap-x-4 gap-y-1.5 mt-2 px-2">
-      {payload.map((entry, index) => (
-        <div key={index} className="flex items-center gap-1.5">
-          <div className="w-2.5 h-2.5 rounded-full flex-shrink-0" style={{ backgroundColor: entry.color }} />
-          <span className="text-xs text-gray-600 whitespace-nowrap">{entry.value}</span>
-        </div>
-      ))}
-    </div>
-  );
-};
-
-// ============================================
-// KPI CARD
-// ============================================
-const KpiCard = ({ title, amount, icon, gradient, yoy }) => (
-  <div className={`relative overflow-hidden rounded-2xl bg-gradient-to-br ${gradient} p-4 sm:p-5 text-white shadow-lg`}>
-    <div className="absolute right-0 top-0 -mr-4 -mt-4 h-24 w-24 rounded-full bg-white/10" />
-    <div className="relative">
-      <div className="flex items-center gap-2 mb-2">
-        <div className="rounded-lg bg-white/20 p-1.5">{icon}</div>
-        <span className="text-sm font-medium text-white/80">{title}</span>
-      </div>
-      <p className="text-2xl sm:text-3xl font-bold tracking-tight truncate">{formatCurrency(amount)}</p>
-      {yoy && yoy.percent !== null && (
-        <p className="text-xs mt-1 text-white/70">
-          {yoy.percent >= 0 ? '+' : ''}{yoy.percent.toFixed(1)}% r/r
-          ({yoy.change >= 0 ? '+' : ''}{formatCurrency(yoy.change)})
-        </p>
-      )}
-    </div>
-  </div>
-);
-
-// ============================================
-// MAIN COMPONENT
-// ============================================
 export default function YearlySummary({ year }) {
   const [activeTab, setActiveTab] = useState('overview');
-  const {
-    prevYearData,
-    availableYears,
-    compareYear,
-    setCompareYear,
-    isLoading,
-    isLoadingCompare,
+  const data = useYearlyData(year);
 
-    monthlyData,
-    totalIncome,
-    totalExpenses,
-    totalBalance,
-    avgMonthlyExpense,
-    cumulativeSavings,
-    categoryData,
-    personData,
-    personPieData,
-    maxCategoryValue,
-
-    yoyIncome,
-    yoyExpenses,
-    yoyBalance,
-
-    compareMonthlyData,
-    compareTotalIncome,
-    compareTotalExpenses,
-    compareChartData,
-    categoryCompareTable,
-  } = useYearlyData(year);
-
-  // ---- Loading state ----
-  if (isLoading) {
+  if (data.isLoading) {
     return (
       <div className="flex items-center justify-center py-20">
         <div className="flex items-center gap-3 text-gray-500">
@@ -193,18 +26,10 @@ export default function YearlySummary({ year }) {
     );
   }
 
-  // ---- TABS ----
-  const tabs = [
-    { id: 'overview', label: 'Przegląd' },
-    { id: 'compare', label: 'Porównanie lat' },
-    { id: 'persons', label: 'Osoby' },
-  ];
-
   return (
     <div className="space-y-6">
-      {/* Tab Navigation */}
       <div className="flex gap-1 bg-white rounded-2xl shadow-sm border border-gray-100 p-1 overflow-x-auto">
-        {tabs.map(tab => (
+        {TABS.map(tab => (
           <button
             key={tab.id}
             onClick={() => setActiveTab(tab.id)}
@@ -219,324 +44,44 @@ export default function YearlySummary({ year }) {
         ))}
       </div>
 
-      {/* ========== OVERVIEW TAB ========== */}
       {activeTab === 'overview' && (
-        <div className="space-y-6">
-          {/* KPI Cards */}
-          <div className="grid grid-cols-2 lg:grid-cols-4 gap-4">
-            <KpiCard title="Przychody roczne" amount={totalIncome} icon={<TrendUpIcon />}
-              gradient="from-emerald-500 to-teal-600" yoy={prevYearData.length > 0 ? yoyIncome : null} />
-            <KpiCard title="Wydatki roczne" amount={totalExpenses} icon={<TrendDownIcon />}
-              gradient="from-rose-500 to-red-600" yoy={prevYearData.length > 0 ? yoyExpenses : null} />
-            <KpiCard title="Bilans roczny" amount={totalBalance} icon={<WalletIcon />}
-              gradient="from-indigo-500 to-purple-600" yoy={prevYearData.length > 0 ? yoyBalance : null} />
-            <KpiCard title="Śr. mies. wydatek" amount={avgMonthlyExpense} icon={<PiggyIcon />}
-              gradient="from-amber-500 to-orange-600" yoy={null} />
-          </div>
-
-          {/* Monthly Income vs Expenses Bar Chart */}
-          <div className="rounded-3xl bg-white/50 backdrop-blur border border-gray-100 shadow-sm p-6">
-            <h3 className="text-lg font-semibold text-gray-800 mb-4">Przychody vs Wydatki</h3>
-            <ResponsiveContainer width="100%" height={300}>
-              <BarChart data={monthlyData} margin={{ top: 5, right: 5, left: 5, bottom: 5 }}>
-                <CartesianGrid strokeDasharray="3 3" stroke="#f1f5f9" vertical={false} />
-                <XAxis dataKey="month" tick={{ fontSize: 11, fill: '#94a3b8' }} axisLine={{ stroke: '#e2e8f0' }} tickLine={false} />
-                <YAxis tick={{ fontSize: 11, fill: '#94a3b8' }} axisLine={false} tickLine={false}
-                  tickFormatter={v => v >= 1000 ? `${(v / 1000).toFixed(0)}k` : v} width={45} />
-                <Tooltip content={<MonthlyBarTooltip />} />
-                <Bar dataKey="przychody" name="Przychody" fill="#10b981" radius={[4, 4, 0, 0]} />
-                <Bar dataKey="wydatki" name="Wydatki" fill="#f43f5e" radius={[4, 4, 0, 0]} />
-              </BarChart>
-            </ResponsiveContainer>
-          </div>
-
-          {/* Cumulative Savings Area Chart */}
-          <div className="rounded-3xl bg-white/50 backdrop-blur border border-gray-100 shadow-sm p-6">
-            <h3 className="text-lg font-semibold text-gray-800 mb-4">Oszczędności skumulowane</h3>
-            <ResponsiveContainer width="100%" height={250}>
-              <AreaChart data={cumulativeSavings} margin={{ top: 5, right: 5, left: 5, bottom: 5 }}>
-                <defs>
-                  <linearGradient id="savingsGradient" x1="0" y1="0" x2="0" y2="1">
-                    <stop offset="5%" stopColor="#6366f1" stopOpacity={0.3} />
-                    <stop offset="95%" stopColor="#6366f1" stopOpacity={0.05} />
-                  </linearGradient>
-                </defs>
-                <CartesianGrid strokeDasharray="3 3" stroke="#f1f5f9" vertical={false} />
-                <XAxis dataKey="month" tick={{ fontSize: 11, fill: '#94a3b8' }} axisLine={{ stroke: '#e2e8f0' }} tickLine={false} />
-                <YAxis tick={{ fontSize: 11, fill: '#94a3b8' }} axisLine={false} tickLine={false}
-                  tickFormatter={v => v >= 1000 ? `${(v / 1000).toFixed(0)}k` : v} width={45} />
-                <Tooltip content={<AreaTooltip />} />
-                <Area type="monotone" dataKey="savings" name="Oszczędności" stroke="#6366f1" strokeWidth={2}
-                  fill="url(#savingsGradient)" />
-              </AreaChart>
-            </ResponsiveContainer>
-          </div>
-
-          {/* Expenses by Category — Pie + Ranking */}
-          <div className="rounded-3xl bg-white/50 backdrop-blur border border-gray-100 shadow-sm p-6">
-            <h3 className="text-lg font-semibold text-gray-800 mb-4">Wydatki wg kategorii</h3>
-            {categoryData.length === 0 ? (
-              <p className="text-gray-400 text-sm text-center py-8">Brak wydatków w tym roku</p>
-            ) : (
-              <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
-                {/* Donut Chart */}
-                <div>
-                  <ResponsiveContainer width="100%" height={280}>
-                    <PieChart>
-                      <Pie data={categoryData} cx="50%" cy="50%" innerRadius={55} outerRadius={110}
-                        paddingAngle={2} dataKey="value" labelLine={false} label={renderPieLabel}>
-                        {categoryData.map((_, i) => (
-                          <Cell key={i} fill={CATEGORY_COLORS[i % CATEGORY_COLORS.length]} stroke="white" strokeWidth={2} />
-                        ))}
-                      </Pie>
-                      <Tooltip content={<PieTooltip />} />
-                      <Legend content={<CustomLegend />} />
-                    </PieChart>
-                  </ResponsiveContainer>
-                </div>
-                {/* Category Ranking */}
-                <div className="space-y-2.5">
-                  {categoryData.map((cat, i) => (
-                    <div key={cat.name} className="flex items-center gap-3">
-                      <div className="w-3 h-3 rounded-full shrink-0"
-                        style={{ backgroundColor: CATEGORY_COLORS[i % CATEGORY_COLORS.length] }} />
-                      <div className="flex-1 min-w-0">
-                        <div className="flex items-center justify-between mb-1">
-                          <span className="text-sm text-gray-700 font-medium truncate">{cat.name}</span>
-                          <span className="text-sm font-semibold text-gray-800 ml-2 whitespace-nowrap">{formatCurrency(cat.value)}</span>
-                        </div>
-                        <div className="w-full bg-gray-100 rounded-full h-2 overflow-hidden">
-                          <div className="h-2 rounded-full transition-all"
-                            style={{
-                              width: `${(cat.value / maxCategoryValue) * 100}%`,
-                              backgroundColor: CATEGORY_COLORS[i % CATEGORY_COLORS.length],
-                            }} />
-                        </div>
-                      </div>
-                    </div>
-                  ))}
-                </div>
-              </div>
-            )}
-          </div>
-        </div>
+        <OverviewTab
+          prevYearData={data.prevYearData}
+          monthlyData={data.monthlyData}
+          totalIncome={data.totalIncome}
+          totalExpenses={data.totalExpenses}
+          totalBalance={data.totalBalance}
+          avgMonthlyExpense={data.avgMonthlyExpense}
+          cumulativeSavings={data.cumulativeSavings}
+          categoryData={data.categoryData}
+          maxCategoryValue={data.maxCategoryValue}
+          yoyIncome={data.yoyIncome}
+          yoyExpenses={data.yoyExpenses}
+          yoyBalance={data.yoyBalance}
+        />
       )}
 
-      {/* ========== COMPARE TAB ========== */}
       {activeTab === 'compare' && (
-        <div className="space-y-6">
-          {/* Year Selector */}
-          <div className="rounded-3xl bg-white/50 backdrop-blur border border-gray-100 shadow-sm p-6">
-            <h3 className="text-lg font-semibold text-gray-800 mb-3">Porównaj z rokiem</h3>
-            <div className="flex flex-wrap gap-2">
-              {availableYears.filter(y => y !== year).map(y => (
-                <button
-                  key={y}
-                  onClick={() => setCompareYear(y === compareYear ? null : y)}
-                  className={`rounded-xl px-4 py-2 text-sm font-medium transition-all ${
-                    compareYear === y
-                      ? 'bg-indigo-500 text-white shadow-sm'
-                      : 'bg-gray-100 text-gray-600 hover:bg-gray-200'
-                  }`}
-                >
-                  {y}
-                </button>
-              ))}
-            </div>
-          </div>
-
-          {!compareYear ? (
-            /* Empty state */
-            <div className="rounded-3xl bg-white/50 backdrop-blur border border-gray-100 shadow-sm p-12 text-center">
-              <div className="text-gray-300 flex justify-center mb-4"><CalendarSearchIcon /></div>
-              <p className="text-gray-500 text-sm">Wybierz rok do porównania</p>
-            </div>
-          ) : isLoadingCompare ? (
-            <div className="flex items-center justify-center py-16">
-              <div className="flex items-center gap-3 text-gray-500">
-                <LoaderIcon />
-                <span>Ładowanie danych porównawczych...</span>
-              </div>
-            </div>
-          ) : (
-            <>
-              {/* Change Cards */}
-              <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
-                {(() => {
-                  const incChange = calculateYoY(totalIncome, compareTotalIncome);
-                  return (
-                    <div className="rounded-2xl bg-white/50 backdrop-blur border border-gray-100 shadow-sm p-5">
-                      <p className="text-sm text-gray-500 mb-1">Zmiana przychodów</p>
-                      <p className={`text-2xl font-bold ${incChange.change >= 0 ? 'text-emerald-600' : 'text-rose-600'}`}>
-                        {incChange.change >= 0 ? '+' : ''}{formatCurrency(incChange.change)}
-                      </p>
-                      {incChange.percent !== null && (
-                        <p className={`text-sm ${incChange.change >= 0 ? 'text-emerald-500' : 'text-rose-500'}`}>
-                          {incChange.percent >= 0 ? '+' : ''}{incChange.percent.toFixed(1)}%
-                        </p>
-                      )}
-                    </div>
-                  );
-                })()}
-                {(() => {
-                  const expChange = calculateYoY(totalExpenses, compareTotalExpenses);
-                  const isBetter = expChange.change <= 0;
-                  return (
-                    <div className="rounded-2xl bg-white/50 backdrop-blur border border-gray-100 shadow-sm p-5">
-                      <p className="text-sm text-gray-500 mb-1">Zmiana wydatków</p>
-                      <p className={`text-2xl font-bold ${isBetter ? 'text-emerald-600' : 'text-rose-600'}`}>
-                        {expChange.change >= 0 ? '+' : ''}{formatCurrency(expChange.change)}
-                      </p>
-                      {expChange.percent !== null && (
-                        <p className={`text-sm ${isBetter ? 'text-emerald-500' : 'text-rose-500'}`}>
-                          {expChange.percent >= 0 ? '+' : ''}{expChange.percent.toFixed(1)}%
-                        </p>
-                      )}
-                    </div>
-                  );
-                })()}
-              </div>
-
-              {/* Side-by-side Expenses Chart */}
-              <div className="rounded-3xl bg-white/50 backdrop-blur border border-gray-100 shadow-sm p-6">
-                <h3 className="text-lg font-semibold text-gray-800 mb-4">Wydatki — porównanie miesięczne</h3>
-                <ResponsiveContainer width="100%" height={300}>
-                  <BarChart data={compareChartData} margin={{ top: 5, right: 5, left: 5, bottom: 5 }}>
-                    <CartesianGrid strokeDasharray="3 3" stroke="#f1f5f9" vertical={false} />
-                    <XAxis dataKey="month" tick={{ fontSize: 11, fill: '#94a3b8' }} axisLine={{ stroke: '#e2e8f0' }} tickLine={false} />
-                    <YAxis tick={{ fontSize: 11, fill: '#94a3b8' }} axisLine={false} tickLine={false}
-                      tickFormatter={v => v >= 1000 ? `${(v / 1000).toFixed(0)}k` : v} width={45} />
-                    <Tooltip content={<MonthlyBarTooltip />} />
-                    <Bar dataKey={`Wydatki ${year}`} fill="#f43f5e" radius={[4, 4, 0, 0]} />
-                    <Bar dataKey={`Wydatki ${compareYear}`} fill="#fda4af" radius={[4, 4, 0, 0]} />
-                  </BarChart>
-                </ResponsiveContainer>
-              </div>
-
-              {/* Side-by-side Income Chart */}
-              <div className="rounded-3xl bg-white/50 backdrop-blur border border-gray-100 shadow-sm p-6">
-                <h3 className="text-lg font-semibold text-gray-800 mb-4">Przychody — porównanie miesięczne</h3>
-                <ResponsiveContainer width="100%" height={300}>
-                  <BarChart data={compareChartData} margin={{ top: 5, right: 5, left: 5, bottom: 5 }}>
-                    <CartesianGrid strokeDasharray="3 3" stroke="#f1f5f9" vertical={false} />
-                    <XAxis dataKey="month" tick={{ fontSize: 11, fill: '#94a3b8' }} axisLine={{ stroke: '#e2e8f0' }} tickLine={false} />
-                    <YAxis tick={{ fontSize: 11, fill: '#94a3b8' }} axisLine={false} tickLine={false}
-                      tickFormatter={v => v >= 1000 ? `${(v / 1000).toFixed(0)}k` : v} width={45} />
-                    <Tooltip content={<MonthlyBarTooltip />} />
-                    <Bar dataKey={`Przychody ${year}`} fill="#10b981" radius={[4, 4, 0, 0]} />
-                    <Bar dataKey={`Przychody ${compareYear}`} fill="#6ee7b7" radius={[4, 4, 0, 0]} />
-                  </BarChart>
-                </ResponsiveContainer>
-              </div>
-
-              {/* Category Comparison Table */}
-              <div className="rounded-3xl bg-white/50 backdrop-blur border border-gray-100 shadow-sm overflow-hidden">
-                <div className="px-6 py-4 border-b border-gray-100">
-                  <h3 className="text-lg font-semibold text-gray-800">Wydatki wg kategorii — porównanie</h3>
-                </div>
-                <div className="overflow-x-auto">
-                  <table className="w-full text-sm">
-                    <thead>
-                      <tr className="bg-gray-50/50">
-                        <th className="text-left px-6 py-3 font-medium text-gray-500">Kategoria</th>
-                        <th className="text-right px-4 py-3 font-medium text-gray-500">{year}</th>
-                        <th className="text-right px-4 py-3 font-medium text-gray-500">{compareYear}</th>
-                        <th className="text-right px-6 py-3 font-medium text-gray-500">Zmiana</th>
-                      </tr>
-                    </thead>
-                    <tbody>
-                      {categoryCompareTable.map(row => (
-                        <tr key={row.name} className="border-t border-gray-100 hover:bg-gray-50/50">
-                          <td className="px-6 py-3 font-medium text-gray-700">{row.name}</td>
-                          <td className="px-4 py-3 text-right text-gray-800">{formatCurrency(row.base)}</td>
-                          <td className="px-4 py-3 text-right text-gray-600">{formatCurrency(row.compare)}</td>
-                          <td className={`px-6 py-3 text-right font-medium ${row.change <= 0 ? 'text-emerald-600' : 'text-rose-600'}`}>
-                            {row.change >= 0 ? '+' : ''}{formatCurrency(row.change)}
-                          </td>
-                        </tr>
-                      ))}
-                    </tbody>
-                  </table>
-                </div>
-              </div>
-            </>
-          )}
-        </div>
+        <CompareTab
+          year={year}
+          availableYears={data.availableYears}
+          compareYear={data.compareYear}
+          setCompareYear={data.setCompareYear}
+          isLoadingCompare={data.isLoadingCompare}
+          totalIncome={data.totalIncome}
+          totalExpenses={data.totalExpenses}
+          compareTotalIncome={data.compareTotalIncome}
+          compareTotalExpenses={data.compareTotalExpenses}
+          compareChartData={data.compareChartData}
+          categoryCompareTable={data.categoryCompareTable}
+        />
       )}
 
-      {/* ========== PERSONS TAB ========== */}
       {activeTab === 'persons' && (
-        <div className="space-y-6">
-          {personData.length === 0 ? (
-            <div className="rounded-3xl bg-white/50 backdrop-blur border border-gray-100 shadow-sm p-12 text-center">
-              <div className="text-gray-300 flex justify-center mb-4"><UserIcon /></div>
-              <p className="text-gray-500 text-sm">Brak danych o osobach w tym roku</p>
-            </div>
-          ) : (
-            <>
-              {/* Person Cards */}
-              <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
-                {personData.map(person => {
-                  const maxVal = Math.max(person.przychody, person.wydatki, 1);
-                  return (
-                    <div key={person.name} className="rounded-2xl bg-white/50 backdrop-blur border border-gray-100 shadow-sm p-5">
-                      <div className="flex items-center gap-3 mb-4">
-                        <div className="w-10 h-10 rounded-full bg-gradient-to-br from-indigo-500 to-purple-600 flex items-center justify-center text-white font-bold text-sm">
-                          {person.name.charAt(0).toUpperCase()}
-                        </div>
-                        <div>
-                          <p className="font-semibold text-gray-800">{person.name}</p>
-                          <p className={`text-sm font-medium ${person.bilans >= 0 ? 'text-emerald-600' : 'text-rose-600'}`}>
-                            Bilans: {formatCurrency(person.bilans)}
-                          </p>
-                        </div>
-                      </div>
-                      {/* Income bar */}
-                      <div className="mb-2">
-                        <div className="flex items-center justify-between text-xs text-gray-500 mb-1">
-                          <span>Przychody</span>
-                          <span className="font-medium text-emerald-600">{formatCurrency(person.przychody)}</span>
-                        </div>
-                        <div className="w-full bg-gray-100 rounded-full h-2 overflow-hidden">
-                          <div className="h-2 rounded-full bg-emerald-400" style={{ width: `${(person.przychody / maxVal) * 100}%` }} />
-                        </div>
-                      </div>
-                      {/* Expense bar */}
-                      <div>
-                        <div className="flex items-center justify-between text-xs text-gray-500 mb-1">
-                          <span>Wydatki</span>
-                          <span className="font-medium text-rose-600">{formatCurrency(person.wydatki)}</span>
-                        </div>
-                        <div className="w-full bg-gray-100 rounded-full h-2 overflow-hidden">
-                          <div className="h-2 rounded-full bg-rose-400" style={{ width: `${(person.wydatki / maxVal) * 100}%` }} />
-                        </div>
-                      </div>
-                    </div>
-                  );
-                })}
-              </div>
-
-              {/* Expense share pie chart */}
-              {personPieData.length > 0 && (
-                <div className="rounded-3xl bg-white/50 backdrop-blur border border-gray-100 shadow-sm p-6">
-                  <h3 className="text-lg font-semibold text-gray-800 mb-4">Udział w wydatkach</h3>
-                  <ResponsiveContainer width="100%" height={280}>
-                    <PieChart>
-                      <Pie data={personPieData} cx="50%" cy="50%" innerRadius={55} outerRadius={110}
-                        paddingAngle={2} dataKey="value" labelLine={false} label={renderPieLabel}>
-                        {personPieData.map((_, i) => (
-                          <Cell key={i} fill={CATEGORY_COLORS[i % CATEGORY_COLORS.length]} stroke="white" strokeWidth={2} />
-                        ))}
-                      </Pie>
-                      <Tooltip content={<PieTooltip />} />
-                      <Legend content={<CustomLegend />} />
-                    </PieChart>
-                  </ResponsiveContainer>
-                </div>
-              )}
-            </>
-          )}
-        </div>
+        <PersonsTab
+          personData={data.personData}
+          personPieData={data.personPieData}
+        />
       )}
     </div>
   );

--- a/src/components/YearlySummary.jsx
+++ b/src/components/YearlySummary.jsx
@@ -1,17 +1,13 @@
-import { useState, useEffect, useMemo } from 'react';
+import { useState } from 'react';
 import {
   BarChart, Bar, XAxis, YAxis, CartesianGrid, Tooltip, ResponsiveContainer,
   AreaChart, Area, PieChart, Pie, Cell, Legend,
 } from 'recharts';
-import * as api from '../services/api';
 import {
   formatCurrency,
   MONTHS_PL_SHORT,
-  aggregateByMonth,
-  aggregateByCategory,
-  aggregateByPerson,
-  calculateYoY,
 } from '../utils/calculations';
+import { useYearlyData } from '../hooks/useYearlyData';
 
 // ============================================
 // COLOR PALETTE (reuse from CategoryCharts)
@@ -154,125 +150,36 @@ const KpiCard = ({ title, amount, icon, gradient, yoy }) => (
 // MAIN COMPONENT
 // ============================================
 export default function YearlySummary({ year }) {
-  const [yearData, setYearData] = useState([]);
-  const [prevYearData, setPrevYearData] = useState([]);
-  const [compareYear, setCompareYear] = useState(null);
-  const [compareData, setCompareData] = useState([]);
-  const [availableYears, setAvailableYears] = useState([]);
   const [activeTab, setActiveTab] = useState('overview');
-  const [isLoading, setIsLoading] = useState(true);
-  const [isLoadingCompare, setIsLoadingCompare] = useState(false);
+  const {
+    prevYearData,
+    availableYears,
+    compareYear,
+    setCompareYear,
+    isLoading,
+    isLoadingCompare,
 
-  // Fetch year data
-  useEffect(() => {
-    let cancelled = false;
-    setIsLoading(true);
-    setCompareYear(null);
-    setCompareData([]);
+    monthlyData,
+    totalIncome,
+    totalExpenses,
+    totalBalance,
+    avgMonthlyExpense,
+    cumulativeSavings,
+    categoryData,
+    personData,
+    personPieData,
+    maxCategoryValue,
 
-    const load = async () => {
-      try {
-        const [data, prevData, years] = await Promise.all([
-          api.getTransakcjeForYear(year),
-          api.getTransakcjeForYear(year - 1).catch(() => []),
-          api.getAvailableYears().catch(() => [year]),
-        ]);
-        if (cancelled) return;
-        setYearData(data || []);
-        setPrevYearData(prevData || []);
-        setAvailableYears(years);
-      } catch {
-        if (!cancelled) {
-          setYearData([]);
-          setPrevYearData([]);
-        }
-      } finally {
-        if (!cancelled) setIsLoading(false);
-      }
-    };
-    load();
-    return () => { cancelled = true; };
-  }, [year]);
+    yoyIncome,
+    yoyExpenses,
+    yoyBalance,
 
-  // Fetch compare year data
-  useEffect(() => {
-    if (!compareYear) { setCompareData([]); return; }
-    let cancelled = false;
-    setIsLoadingCompare(true);
-    api.getTransakcjeForYear(compareYear)
-      .then(data => { if (!cancelled) setCompareData(data || []); })
-      .catch(() => { if (!cancelled) setCompareData([]); })
-      .finally(() => { if (!cancelled) setIsLoadingCompare(false); });
-    return () => { cancelled = true; };
-  }, [compareYear]);
-
-  // ---- Computations ----
-  const monthlyData = useMemo(() => aggregateByMonth(yearData), [yearData]);
-  const prevMonthlyData = useMemo(() => aggregateByMonth(prevYearData), [prevYearData]);
-
-  const totalIncome = useMemo(() => monthlyData.reduce((s, m) => s + m.przychody, 0), [monthlyData]);
-  const totalExpenses = useMemo(() => monthlyData.reduce((s, m) => s + m.wydatki, 0), [monthlyData]);
-  const totalBalance = totalIncome - totalExpenses;
-  const avgMonthlyExpense = totalExpenses / 12;
-
-  const prevTotalIncome = useMemo(() => prevMonthlyData.reduce((s, m) => s + m.przychody, 0), [prevMonthlyData]);
-  const prevTotalExpenses = useMemo(() => prevMonthlyData.reduce((s, m) => s + m.wydatki, 0), [prevMonthlyData]);
-  const prevTotalBalance = prevTotalIncome - prevTotalExpenses;
-
-  const yoyIncome = useMemo(() => calculateYoY(totalIncome, prevTotalIncome), [totalIncome, prevTotalIncome]);
-  const yoyExpenses = useMemo(() => calculateYoY(totalExpenses, prevTotalExpenses), [totalExpenses, prevTotalExpenses]);
-  const yoyBalance = useMemo(() => calculateYoY(totalBalance, prevTotalBalance), [totalBalance, prevTotalBalance]);
-
-  const cumulativeSavings = useMemo(() => {
-    let cum = 0;
-    return monthlyData.map(m => {
-      cum += (m.przychody - m.wydatki);
-      return { month: m.month, savings: Math.round(cum * 100) / 100 };
-    });
-  }, [monthlyData]);
-
-  const categoryData = useMemo(() => aggregateByCategory(yearData, 'Wydatek'), [yearData]);
-  const personData = useMemo(() => aggregateByPerson(yearData), [yearData]);
-
-  // Compare tab computations
-  const compareMonthlyData = useMemo(() => aggregateByMonth(compareData), [compareData]);
-  const compareCategoryData = useMemo(() => aggregateByCategory(compareData, 'Wydatek'), [compareData]);
-  const compareTotalIncome = useMemo(() => compareMonthlyData.reduce((s, m) => s + m.przychody, 0), [compareMonthlyData]);
-  const compareTotalExpenses = useMemo(() => compareMonthlyData.reduce((s, m) => s + m.wydatki, 0), [compareMonthlyData]);
-
-  const maxCategoryValue = categoryData.length > 0 ? categoryData[0].value : 1;
-
-  // Compare tab — side by side monthly data
-  const compareChartData = useMemo(() => {
-    if (!compareYear) return [];
-    return MONTHS_PL_SHORT.map((m, i) => ({
-      month: m,
-      [`Wydatki ${year}`]: monthlyData[i].wydatki,
-      [`Wydatki ${compareYear}`]: compareMonthlyData[i].wydatki,
-      [`Przychody ${year}`]: monthlyData[i].przychody,
-      [`Przychody ${compareYear}`]: compareMonthlyData[i].przychody,
-    }));
-  }, [compareYear, year, monthlyData, compareMonthlyData]);
-
-  // Compare tab — category comparison table
-  const categoryCompareTable = useMemo(() => {
-    if (!compareYear) return [];
-    const map = new Map();
-    categoryData.forEach(c => map.set(c.name, { base: c.value, compare: 0 }));
-    compareCategoryData.forEach(c => {
-      if (map.has(c.name)) map.get(c.name).compare = c.value;
-      else map.set(c.name, { base: 0, compare: c.value });
-    });
-    return Array.from(map.entries())
-      .map(([name, { base, compare }]) => ({ name, base, compare, change: base - compare }))
-      .sort((a, b) => b.base - a.base);
-  }, [compareYear, categoryData, compareCategoryData]);
-
-  // Person data for pie chart
-  const personPieData = useMemo(() =>
-    personData.map(p => ({ name: p.name, value: p.wydatki })).filter(p => p.value > 0),
-    [personData]
-  );
+    compareMonthlyData,
+    compareTotalIncome,
+    compareTotalExpenses,
+    compareChartData,
+    categoryCompareTable,
+  } = useYearlyData(year);
 
   // ---- Loading state ----
   if (isLoading) {

--- a/src/components/yearly/CompareTab.jsx
+++ b/src/components/yearly/CompareTab.jsx
@@ -1,0 +1,159 @@
+import {
+  BarChart, Bar, XAxis, YAxis, CartesianGrid, Tooltip, ResponsiveContainer,
+} from 'recharts';
+import { formatCurrency, calculateYoY } from '../../utils/calculations';
+import {
+  CalendarSearchIcon, LoaderIcon, MonthlyBarTooltip,
+} from './primitives';
+
+export default function CompareTab({
+  year,
+  availableYears,
+  compareYear,
+  setCompareYear,
+  isLoadingCompare,
+  totalIncome,
+  totalExpenses,
+  compareTotalIncome,
+  compareTotalExpenses,
+  compareChartData,
+  categoryCompareTable,
+}) {
+  return (
+    <div className="space-y-6">
+      <div className="rounded-3xl bg-white/50 backdrop-blur border border-gray-100 shadow-sm p-6">
+        <h3 className="text-lg font-semibold text-gray-800 mb-3">Porównaj z rokiem</h3>
+        <div className="flex flex-wrap gap-2">
+          {availableYears.filter(y => y !== year).map(y => (
+            <button
+              key={y}
+              onClick={() => setCompareYear(y === compareYear ? null : y)}
+              className={`rounded-xl px-4 py-2 text-sm font-medium transition-all ${
+                compareYear === y
+                  ? 'bg-indigo-500 text-white shadow-sm'
+                  : 'bg-gray-100 text-gray-600 hover:bg-gray-200'
+              }`}
+            >
+              {y}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      {!compareYear ? (
+        <div className="rounded-3xl bg-white/50 backdrop-blur border border-gray-100 shadow-sm p-12 text-center">
+          <div className="text-gray-300 flex justify-center mb-4"><CalendarSearchIcon /></div>
+          <p className="text-gray-500 text-sm">Wybierz rok do porównania</p>
+        </div>
+      ) : isLoadingCompare ? (
+        <div className="flex items-center justify-center py-16">
+          <div className="flex items-center gap-3 text-gray-500">
+            <LoaderIcon />
+            <span>Ładowanie danych porównawczych...</span>
+          </div>
+        </div>
+      ) : (
+        <>
+          <ChangeCards
+            totalIncome={totalIncome}
+            totalExpenses={totalExpenses}
+            compareTotalIncome={compareTotalIncome}
+            compareTotalExpenses={compareTotalExpenses}
+          />
+
+          <div className="rounded-3xl bg-white/50 backdrop-blur border border-gray-100 shadow-sm p-6">
+            <h3 className="text-lg font-semibold text-gray-800 mb-4">Wydatki — porównanie miesięczne</h3>
+            <ResponsiveContainer width="100%" height={300}>
+              <BarChart data={compareChartData} margin={{ top: 5, right: 5, left: 5, bottom: 5 }}>
+                <CartesianGrid strokeDasharray="3 3" stroke="#f1f5f9" vertical={false} />
+                <XAxis dataKey="month" tick={{ fontSize: 11, fill: '#94a3b8' }} axisLine={{ stroke: '#e2e8f0' }} tickLine={false} />
+                <YAxis tick={{ fontSize: 11, fill: '#94a3b8' }} axisLine={false} tickLine={false}
+                  tickFormatter={v => v >= 1000 ? `${(v / 1000).toFixed(0)}k` : v} width={45} />
+                <Tooltip content={<MonthlyBarTooltip />} />
+                <Bar dataKey={`Wydatki ${year}`} fill="#f43f5e" radius={[4, 4, 0, 0]} />
+                <Bar dataKey={`Wydatki ${compareYear}`} fill="#fda4af" radius={[4, 4, 0, 0]} />
+              </BarChart>
+            </ResponsiveContainer>
+          </div>
+
+          <div className="rounded-3xl bg-white/50 backdrop-blur border border-gray-100 shadow-sm p-6">
+            <h3 className="text-lg font-semibold text-gray-800 mb-4">Przychody — porównanie miesięczne</h3>
+            <ResponsiveContainer width="100%" height={300}>
+              <BarChart data={compareChartData} margin={{ top: 5, right: 5, left: 5, bottom: 5 }}>
+                <CartesianGrid strokeDasharray="3 3" stroke="#f1f5f9" vertical={false} />
+                <XAxis dataKey="month" tick={{ fontSize: 11, fill: '#94a3b8' }} axisLine={{ stroke: '#e2e8f0' }} tickLine={false} />
+                <YAxis tick={{ fontSize: 11, fill: '#94a3b8' }} axisLine={false} tickLine={false}
+                  tickFormatter={v => v >= 1000 ? `${(v / 1000).toFixed(0)}k` : v} width={45} />
+                <Tooltip content={<MonthlyBarTooltip />} />
+                <Bar dataKey={`Przychody ${year}`} fill="#10b981" radius={[4, 4, 0, 0]} />
+                <Bar dataKey={`Przychody ${compareYear}`} fill="#6ee7b7" radius={[4, 4, 0, 0]} />
+              </BarChart>
+            </ResponsiveContainer>
+          </div>
+
+          <div className="rounded-3xl bg-white/50 backdrop-blur border border-gray-100 shadow-sm overflow-hidden">
+            <div className="px-6 py-4 border-b border-gray-100">
+              <h3 className="text-lg font-semibold text-gray-800">Wydatki wg kategorii — porównanie</h3>
+            </div>
+            <div className="overflow-x-auto">
+              <table className="w-full text-sm">
+                <thead>
+                  <tr className="bg-gray-50/50">
+                    <th className="text-left px-6 py-3 font-medium text-gray-500">Kategoria</th>
+                    <th className="text-right px-4 py-3 font-medium text-gray-500">{year}</th>
+                    <th className="text-right px-4 py-3 font-medium text-gray-500">{compareYear}</th>
+                    <th className="text-right px-6 py-3 font-medium text-gray-500">Zmiana</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {categoryCompareTable.map(row => (
+                    <tr key={row.name} className="border-t border-gray-100 hover:bg-gray-50/50">
+                      <td className="px-6 py-3 font-medium text-gray-700">{row.name}</td>
+                      <td className="px-4 py-3 text-right text-gray-800">{formatCurrency(row.base)}</td>
+                      <td className="px-4 py-3 text-right text-gray-600">{formatCurrency(row.compare)}</td>
+                      <td className={`px-6 py-3 text-right font-medium ${row.change <= 0 ? 'text-emerald-600' : 'text-rose-600'}`}>
+                        {row.change >= 0 ? '+' : ''}{formatCurrency(row.change)}
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          </div>
+        </>
+      )}
+    </div>
+  );
+}
+
+function ChangeCards({ totalIncome, totalExpenses, compareTotalIncome, compareTotalExpenses }) {
+  const incChange = calculateYoY(totalIncome, compareTotalIncome);
+  const expChange = calculateYoY(totalExpenses, compareTotalExpenses);
+  const isBetterExpense = expChange.change <= 0;
+  return (
+    <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+      <div className="rounded-2xl bg-white/50 backdrop-blur border border-gray-100 shadow-sm p-5">
+        <p className="text-sm text-gray-500 mb-1">Zmiana przychodów</p>
+        <p className={`text-2xl font-bold ${incChange.change >= 0 ? 'text-emerald-600' : 'text-rose-600'}`}>
+          {incChange.change >= 0 ? '+' : ''}{formatCurrency(incChange.change)}
+        </p>
+        {incChange.percent !== null && (
+          <p className={`text-sm ${incChange.change >= 0 ? 'text-emerald-500' : 'text-rose-500'}`}>
+            {incChange.percent >= 0 ? '+' : ''}{incChange.percent.toFixed(1)}%
+          </p>
+        )}
+      </div>
+      <div className="rounded-2xl bg-white/50 backdrop-blur border border-gray-100 shadow-sm p-5">
+        <p className="text-sm text-gray-500 mb-1">Zmiana wydatków</p>
+        <p className={`text-2xl font-bold ${isBetterExpense ? 'text-emerald-600' : 'text-rose-600'}`}>
+          {expChange.change >= 0 ? '+' : ''}{formatCurrency(expChange.change)}
+        </p>
+        {expChange.percent !== null && (
+          <p className={`text-sm ${isBetterExpense ? 'text-emerald-500' : 'text-rose-500'}`}>
+            {expChange.percent >= 0 ? '+' : ''}{expChange.percent.toFixed(1)}%
+          </p>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/components/yearly/OverviewTab.jsx
+++ b/src/components/yearly/OverviewTab.jsx
@@ -1,0 +1,122 @@
+import {
+  BarChart, Bar, XAxis, YAxis, CartesianGrid, Tooltip, ResponsiveContainer,
+  AreaChart, Area, PieChart, Pie, Cell, Legend,
+} from 'recharts';
+import { formatCurrency } from '../../utils/calculations';
+import {
+  CATEGORY_COLORS,
+  TrendUpIcon, TrendDownIcon, WalletIcon, PiggyIcon,
+  MonthlyBarTooltip, AreaTooltip, PieTooltip, renderPieLabel, CustomLegend, KpiCard,
+} from './primitives';
+
+export default function OverviewTab({
+  prevYearData,
+  monthlyData,
+  totalIncome,
+  totalExpenses,
+  totalBalance,
+  avgMonthlyExpense,
+  cumulativeSavings,
+  categoryData,
+  maxCategoryValue,
+  yoyIncome,
+  yoyExpenses,
+  yoyBalance,
+}) {
+  const hasPrev = prevYearData.length > 0;
+  return (
+    <div className="space-y-6">
+      <div className="grid grid-cols-2 lg:grid-cols-4 gap-4">
+        <KpiCard title="Przychody roczne" amount={totalIncome} icon={<TrendUpIcon />}
+          gradient="from-emerald-500 to-teal-600" yoy={hasPrev ? yoyIncome : null} />
+        <KpiCard title="Wydatki roczne" amount={totalExpenses} icon={<TrendDownIcon />}
+          gradient="from-rose-500 to-red-600" yoy={hasPrev ? yoyExpenses : null} />
+        <KpiCard title="Bilans roczny" amount={totalBalance} icon={<WalletIcon />}
+          gradient="from-indigo-500 to-purple-600" yoy={hasPrev ? yoyBalance : null} />
+        <KpiCard title="Śr. mies. wydatek" amount={avgMonthlyExpense} icon={<PiggyIcon />}
+          gradient="from-amber-500 to-orange-600" yoy={null} />
+      </div>
+
+      <div className="rounded-3xl bg-white/50 backdrop-blur border border-gray-100 shadow-sm p-6">
+        <h3 className="text-lg font-semibold text-gray-800 mb-4">Przychody vs Wydatki</h3>
+        <ResponsiveContainer width="100%" height={300}>
+          <BarChart data={monthlyData} margin={{ top: 5, right: 5, left: 5, bottom: 5 }}>
+            <CartesianGrid strokeDasharray="3 3" stroke="#f1f5f9" vertical={false} />
+            <XAxis dataKey="month" tick={{ fontSize: 11, fill: '#94a3b8' }} axisLine={{ stroke: '#e2e8f0' }} tickLine={false} />
+            <YAxis tick={{ fontSize: 11, fill: '#94a3b8' }} axisLine={false} tickLine={false}
+              tickFormatter={v => v >= 1000 ? `${(v / 1000).toFixed(0)}k` : v} width={45} />
+            <Tooltip content={<MonthlyBarTooltip />} />
+            <Bar dataKey="przychody" name="Przychody" fill="#10b981" radius={[4, 4, 0, 0]} />
+            <Bar dataKey="wydatki" name="Wydatki" fill="#f43f5e" radius={[4, 4, 0, 0]} />
+          </BarChart>
+        </ResponsiveContainer>
+      </div>
+
+      <div className="rounded-3xl bg-white/50 backdrop-blur border border-gray-100 shadow-sm p-6">
+        <h3 className="text-lg font-semibold text-gray-800 mb-4">Oszczędności skumulowane</h3>
+        <ResponsiveContainer width="100%" height={250}>
+          <AreaChart data={cumulativeSavings} margin={{ top: 5, right: 5, left: 5, bottom: 5 }}>
+            <defs>
+              <linearGradient id="savingsGradient" x1="0" y1="0" x2="0" y2="1">
+                <stop offset="5%" stopColor="#6366f1" stopOpacity={0.3} />
+                <stop offset="95%" stopColor="#6366f1" stopOpacity={0.05} />
+              </linearGradient>
+            </defs>
+            <CartesianGrid strokeDasharray="3 3" stroke="#f1f5f9" vertical={false} />
+            <XAxis dataKey="month" tick={{ fontSize: 11, fill: '#94a3b8' }} axisLine={{ stroke: '#e2e8f0' }} tickLine={false} />
+            <YAxis tick={{ fontSize: 11, fill: '#94a3b8' }} axisLine={false} tickLine={false}
+              tickFormatter={v => v >= 1000 ? `${(v / 1000).toFixed(0)}k` : v} width={45} />
+            <Tooltip content={<AreaTooltip />} />
+            <Area type="monotone" dataKey="savings" name="Oszczędności" stroke="#6366f1" strokeWidth={2}
+              fill="url(#savingsGradient)" />
+          </AreaChart>
+        </ResponsiveContainer>
+      </div>
+
+      <div className="rounded-3xl bg-white/50 backdrop-blur border border-gray-100 shadow-sm p-6">
+        <h3 className="text-lg font-semibold text-gray-800 mb-4">Wydatki wg kategorii</h3>
+        {categoryData.length === 0 ? (
+          <p className="text-gray-400 text-sm text-center py-8">Brak wydatków w tym roku</p>
+        ) : (
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+            <div>
+              <ResponsiveContainer width="100%" height={280}>
+                <PieChart>
+                  <Pie data={categoryData} cx="50%" cy="50%" innerRadius={55} outerRadius={110}
+                    paddingAngle={2} dataKey="value" labelLine={false} label={renderPieLabel}>
+                    {categoryData.map((_, i) => (
+                      <Cell key={i} fill={CATEGORY_COLORS[i % CATEGORY_COLORS.length]} stroke="white" strokeWidth={2} />
+                    ))}
+                  </Pie>
+                  <Tooltip content={<PieTooltip />} />
+                  <Legend content={<CustomLegend />} />
+                </PieChart>
+              </ResponsiveContainer>
+            </div>
+            <div className="space-y-2.5">
+              {categoryData.map((cat, i) => (
+                <div key={cat.name} className="flex items-center gap-3">
+                  <div className="w-3 h-3 rounded-full shrink-0"
+                    style={{ backgroundColor: CATEGORY_COLORS[i % CATEGORY_COLORS.length] }} />
+                  <div className="flex-1 min-w-0">
+                    <div className="flex items-center justify-between mb-1">
+                      <span className="text-sm text-gray-700 font-medium truncate">{cat.name}</span>
+                      <span className="text-sm font-semibold text-gray-800 ml-2 whitespace-nowrap">{formatCurrency(cat.value)}</span>
+                    </div>
+                    <div className="w-full bg-gray-100 rounded-full h-2 overflow-hidden">
+                      <div className="h-2 rounded-full transition-all"
+                        style={{
+                          width: `${(cat.value / maxCategoryValue) * 100}%`,
+                          backgroundColor: CATEGORY_COLORS[i % CATEGORY_COLORS.length],
+                        }} />
+                    </div>
+                  </div>
+                </div>
+              ))}
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/components/yearly/PersonsTab.jsx
+++ b/src/components/yearly/PersonsTab.jsx
@@ -1,0 +1,81 @@
+import {
+  PieChart, Pie, Cell, Tooltip, Legend, ResponsiveContainer,
+} from 'recharts';
+import { formatCurrency } from '../../utils/calculations';
+import {
+  CATEGORY_COLORS,
+  UserIcon, PieTooltip, CustomLegend, renderPieLabel,
+} from './primitives';
+
+export default function PersonsTab({ personData, personPieData }) {
+  if (personData.length === 0) {
+    return (
+      <div className="space-y-6">
+        <div className="rounded-3xl bg-white/50 backdrop-blur border border-gray-100 shadow-sm p-12 text-center">
+          <div className="text-gray-300 flex justify-center mb-4"><UserIcon /></div>
+          <p className="text-gray-500 text-sm">Brak danych o osobach w tym roku</p>
+        </div>
+      </div>
+    );
+  }
+  return (
+    <div className="space-y-6">
+      <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+        {personData.map(person => {
+          const maxVal = Math.max(person.przychody, person.wydatki, 1);
+          return (
+            <div key={person.name} className="rounded-2xl bg-white/50 backdrop-blur border border-gray-100 shadow-sm p-5">
+              <div className="flex items-center gap-3 mb-4">
+                <div className="w-10 h-10 rounded-full bg-gradient-to-br from-indigo-500 to-purple-600 flex items-center justify-center text-white font-bold text-sm">
+                  {person.name.charAt(0).toUpperCase()}
+                </div>
+                <div>
+                  <p className="font-semibold text-gray-800">{person.name}</p>
+                  <p className={`text-sm font-medium ${person.bilans >= 0 ? 'text-emerald-600' : 'text-rose-600'}`}>
+                    Bilans: {formatCurrency(person.bilans)}
+                  </p>
+                </div>
+              </div>
+              <div className="mb-2">
+                <div className="flex items-center justify-between text-xs text-gray-500 mb-1">
+                  <span>Przychody</span>
+                  <span className="font-medium text-emerald-600">{formatCurrency(person.przychody)}</span>
+                </div>
+                <div className="w-full bg-gray-100 rounded-full h-2 overflow-hidden">
+                  <div className="h-2 rounded-full bg-emerald-400" style={{ width: `${(person.przychody / maxVal) * 100}%` }} />
+                </div>
+              </div>
+              <div>
+                <div className="flex items-center justify-between text-xs text-gray-500 mb-1">
+                  <span>Wydatki</span>
+                  <span className="font-medium text-rose-600">{formatCurrency(person.wydatki)}</span>
+                </div>
+                <div className="w-full bg-gray-100 rounded-full h-2 overflow-hidden">
+                  <div className="h-2 rounded-full bg-rose-400" style={{ width: `${(person.wydatki / maxVal) * 100}%` }} />
+                </div>
+              </div>
+            </div>
+          );
+        })}
+      </div>
+
+      {personPieData.length > 0 && (
+        <div className="rounded-3xl bg-white/50 backdrop-blur border border-gray-100 shadow-sm p-6">
+          <h3 className="text-lg font-semibold text-gray-800 mb-4">Udział w wydatkach</h3>
+          <ResponsiveContainer width="100%" height={280}>
+            <PieChart>
+              <Pie data={personPieData} cx="50%" cy="50%" innerRadius={55} outerRadius={110}
+                paddingAngle={2} dataKey="value" labelLine={false} label={renderPieLabel}>
+                {personPieData.map((_, i) => (
+                  <Cell key={i} fill={CATEGORY_COLORS[i % CATEGORY_COLORS.length]} stroke="white" strokeWidth={2} />
+                ))}
+              </Pie>
+              <Tooltip content={<PieTooltip />} />
+              <Legend content={<CustomLegend />} />
+            </PieChart>
+          </ResponsiveContainer>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/yearly/primitives.jsx
+++ b/src/components/yearly/primitives.jsx
@@ -1,0 +1,128 @@
+import { formatCurrency } from '../../utils/calculations';
+
+// Shared palette + chart tooltips + KPI card used across all yearly-summary tabs.
+
+export const CATEGORY_COLORS = [
+  '#6366f1', '#f43f5e', '#10b981', '#f59e0b', '#8b5cf6',
+  '#06b6d4', '#ec4899', '#84cc16', '#ef4444', '#14b8a6',
+  '#a855f7', '#f97316', '#3b82f6', '#eab308', '#22d3ee',
+];
+
+export const TrendUpIcon = () => (
+  <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+    <polyline points="23 6 13.5 15.5 8.5 10.5 1 18" /><polyline points="17 6 23 6 23 12" />
+  </svg>
+);
+export const TrendDownIcon = () => (
+  <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+    <polyline points="23 18 13.5 8.5 8.5 13.5 1 6" /><polyline points="17 18 23 18 23 12" />
+  </svg>
+);
+export const WalletIcon = () => (
+  <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+    <path d="M21 12V7H5a2 2 0 0 1 0-4h14v4" /><path d="M3 5v14a2 2 0 0 0 2 2h16v-5" /><path d="M18 12a2 2 0 0 0 0 4h4v-4Z" />
+  </svg>
+);
+export const PiggyIcon = () => (
+  <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+    <path d="M19 5c-1.5 0-2.8 1.4-3 2-3.5-1.5-11-.3-11 5 0 1.8 0 3 2 4.5V20h4v-2h3v2h4v-4c1-.5 1.7-1 2-2h2v-4h-2c0-1-.5-1.5-1-2" />
+    <path d="M2 9.5a.5.5 0 1 0 1 0 .5.5 0 0 0-1 0" />
+  </svg>
+);
+export const LoaderIcon = () => (
+  <svg className="animate-spin" xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+    <path d="M21 12a9 9 0 1 1-6.219-8.56" />
+  </svg>
+);
+export const CalendarSearchIcon = () => (
+  <svg xmlns="http://www.w3.org/2000/svg" width="48" height="48" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round">
+    <rect x="3" y="4" width="18" height="18" rx="2" ry="2" /><line x1="16" y1="2" x2="16" y2="6" /><line x1="8" y1="2" x2="8" y2="6" /><line x1="3" y1="10" x2="21" y2="10" />
+  </svg>
+);
+export const UserIcon = () => (
+  <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+    <path d="M20 21v-2a4 4 0 0 0-4-4H8a4 4 0 0 0-4 4v2" /><circle cx="12" cy="7" r="4" />
+  </svg>
+);
+
+export const MonthlyBarTooltip = ({ active, payload, label }) => {
+  if (!active || !payload?.length) return null;
+  return (
+    <div className="bg-white rounded-xl shadow-lg border border-gray-100 px-4 py-3">
+      <p className="font-semibold text-gray-800 text-sm mb-1">{label}</p>
+      {payload.map((entry, idx) => (
+        <p key={idx} className="text-sm" style={{ color: entry.color }}>
+          {entry.name}: {formatCurrency(entry.value)}
+        </p>
+      ))}
+    </div>
+  );
+};
+
+export const AreaTooltip = ({ active, payload, label }) => {
+  if (!active || !payload?.length) return null;
+  return (
+    <div className="bg-white rounded-xl shadow-lg border border-gray-100 px-4 py-3">
+      <p className="font-semibold text-gray-800 text-sm">{label}</p>
+      <p className="text-indigo-600 text-sm">{formatCurrency(payload[0].value)}</p>
+    </div>
+  );
+};
+
+export const PieTooltip = ({ active, payload }) => {
+  if (!active || !payload?.length) return null;
+  const d = payload[0];
+  return (
+    <div className="bg-white rounded-xl shadow-lg border border-gray-100 px-4 py-3">
+      <p className="font-semibold text-gray-800 text-sm">{d.name}</p>
+      <p className="text-gray-600 text-sm">{formatCurrency(d.value)}</p>
+    </div>
+  );
+};
+
+export const renderPieLabel = ({ cx, cy, midAngle, innerRadius, outerRadius, percent }) => {
+  if (percent < 0.05) return null;
+  const RADIAN = Math.PI / 180;
+  const radius = innerRadius + (outerRadius - innerRadius) * 0.5;
+  const x = cx + radius * Math.cos(-midAngle * RADIAN);
+  const y = cy + radius * Math.sin(-midAngle * RADIAN);
+  return (
+    <text x={x} y={y} fill="white" textAnchor="middle" dominantBaseline="central"
+      className="text-xs font-semibold" style={{ textShadow: '0 1px 2px rgba(0,0,0,0.3)' }}>
+      {(percent * 100).toFixed(0)}%
+    </text>
+  );
+};
+
+export const CustomLegend = ({ payload }) => {
+  if (!payload) return null;
+  return (
+    <div className="flex flex-wrap justify-center gap-x-4 gap-y-1.5 mt-2 px-2">
+      {payload.map((entry, index) => (
+        <div key={index} className="flex items-center gap-1.5">
+          <div className="w-2.5 h-2.5 rounded-full flex-shrink-0" style={{ backgroundColor: entry.color }} />
+          <span className="text-xs text-gray-600 whitespace-nowrap">{entry.value}</span>
+        </div>
+      ))}
+    </div>
+  );
+};
+
+export const KpiCard = ({ title, amount, icon, gradient, yoy }) => (
+  <div className={`relative overflow-hidden rounded-2xl bg-gradient-to-br ${gradient} p-4 sm:p-5 text-white shadow-lg`}>
+    <div className="absolute right-0 top-0 -mr-4 -mt-4 h-24 w-24 rounded-full bg-white/10" />
+    <div className="relative">
+      <div className="flex items-center gap-2 mb-2">
+        <div className="rounded-lg bg-white/20 p-1.5">{icon}</div>
+        <span className="text-sm font-medium text-white/80">{title}</span>
+      </div>
+      <p className="text-2xl sm:text-3xl font-bold tracking-tight truncate">{formatCurrency(amount)}</p>
+      {yoy && yoy.percent !== null && (
+        <p className="text-xs mt-1 text-white/70">
+          {yoy.percent >= 0 ? '+' : ''}{yoy.percent.toFixed(1)}% r/r
+          ({yoy.change >= 0 ? '+' : ''}{formatCurrency(yoy.change)})
+        </p>
+      )}
+    </div>
+  </div>
+);

--- a/src/hooks/__tests__/useAvailableYears.test.js
+++ b/src/hooks/__tests__/useAvailableYears.test.js
@@ -1,0 +1,64 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { renderHook, waitFor } from '@testing-library/react';
+
+vi.mock('../../services/api', () => ({
+  getAvailableYears: vi.fn(),
+}));
+
+import * as api from '../../services/api';
+import { useAvailableYears } from '../useAvailableYears';
+
+describe('useAvailableYears', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('zwraca bieżący rok na początku (przed rozwiązaniem promise)', () => {
+    api.getAvailableYears.mockReturnValue(new Promise(() => {}));
+    const { result } = renderHook(() => useAvailableYears());
+    expect(result.current).toEqual([new Date().getFullYear()]);
+  });
+
+  it('aktualizuje listę po rozwiązaniu api.getAvailableYears', async () => {
+    api.getAvailableYears.mockResolvedValue([2026, 2025, 2024]);
+    const { result } = renderHook(() => useAvailableYears());
+    await waitFor(() => {
+      expect(result.current).toEqual([2026, 2025, 2024]);
+    });
+  });
+
+  it('nie wywołuje API gdy enabled=false', () => {
+    api.getAvailableYears.mockResolvedValue([2026]);
+    renderHook(() => useAvailableYears({ enabled: false }));
+    expect(api.getAvailableYears).not.toHaveBeenCalled();
+  });
+
+  it('wywołuje API gdy enabled=true', async () => {
+    api.getAvailableYears.mockResolvedValue([2026]);
+    const { result } = renderHook(() => useAvailableYears({ enabled: true }));
+    await waitFor(() => {
+      expect(result.current).toEqual([2026]);
+    });
+    expect(api.getAvailableYears).toHaveBeenCalledTimes(1);
+  });
+
+  it('ignoruje błędy API i zostawia wartość początkową', async () => {
+    api.getAvailableYears.mockRejectedValue(new Error('network'));
+    const { result } = renderHook(() => useAvailableYears());
+    await waitFor(() => {
+      expect(api.getAvailableYears).toHaveBeenCalled();
+    });
+    expect(result.current).toEqual([new Date().getFullYear()]);
+  });
+
+  it('nie aktualizuje stanu po unmount (cancellation flag)', async () => {
+    let resolve;
+    api.getAvailableYears.mockReturnValue(new Promise(r => { resolve = r; }));
+    const { result, unmount } = renderHook(() => useAvailableYears());
+    const initial = result.current;
+    unmount();
+    resolve([1999, 2000]);
+    await new Promise(r => setTimeout(r, 0));
+    expect(result.current).toBe(initial);
+  });
+});

--- a/src/hooks/__tests__/useBudgets.test.js
+++ b/src/hooks/__tests__/useBudgets.test.js
@@ -1,0 +1,82 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { renderHook, waitFor, act } from '@testing-library/react';
+
+vi.mock('../../services/api', () => ({
+  getBudgets: vi.fn(),
+}));
+vi.mock('../../utils/logger', () => ({
+  logger: { warn: vi.fn(), error: vi.fn(), info: vi.fn(), debug: vi.fn() },
+}));
+
+import * as api from '../../services/api';
+import { logger } from '../../utils/logger';
+import { useBudgets } from '../useBudgets';
+
+describe('useBudgets', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('pobiera budżety przy montowaniu i zwraca je', async () => {
+    api.getBudgets.mockResolvedValue([{ kategoria: 'Jedzenie', kwota: 1000 }]);
+    const { result } = renderHook(() => useBudgets({ month: 2, year: 2026 }));
+    await waitFor(() => {
+      expect(result.current.budgets).toEqual([{ kategoria: 'Jedzenie', kwota: 1000 }]);
+    });
+    expect(api.getBudgets).toHaveBeenCalledWith(2, 2026);
+  });
+
+  it('zwraca pustą tablicę gdy API zwraca nie-tablicę', async () => {
+    api.getBudgets.mockResolvedValue(null);
+    const { result } = renderHook(() => useBudgets({ month: 1, year: 2026 }));
+    await waitFor(() => {
+      expect(api.getBudgets).toHaveBeenCalled();
+    });
+    expect(result.current.budgets).toEqual([]);
+  });
+
+  it('loguje ostrzeżenie i zostawia pustą listę przy błędzie', async () => {
+    api.getBudgets.mockRejectedValue(new Error('boom'));
+    const { result } = renderHook(() => useBudgets({ month: 1, year: 2026 }));
+    await waitFor(() => {
+      expect(logger.warn).toHaveBeenCalled();
+    });
+    expect(result.current.budgets).toEqual([]);
+  });
+
+  it('nie pobiera danych gdy enabled=false', () => {
+    api.getBudgets.mockResolvedValue([]);
+    renderHook(() => useBudgets({ month: 1, year: 2026, enabled: false }));
+    expect(api.getBudgets).not.toHaveBeenCalled();
+  });
+
+  it('pobiera ponownie gdy zmienia się miesiąc lub rok', async () => {
+    api.getBudgets.mockResolvedValue([]);
+    const { rerender } = renderHook(
+      ({ month, year }) => useBudgets({ month, year }),
+      { initialProps: { month: 1, year: 2026 } }
+    );
+    await waitFor(() => {
+      expect(api.getBudgets).toHaveBeenCalledWith(1, 2026);
+    });
+    rerender({ month: 2, year: 2026 });
+    await waitFor(() => {
+      expect(api.getBudgets).toHaveBeenCalledWith(2, 2026);
+    });
+    expect(api.getBudgets).toHaveBeenCalledTimes(2);
+  });
+
+  it('refresh() ponownie pobiera dane na żądanie', async () => {
+    api.getBudgets.mockResolvedValue([]);
+    const { result } = renderHook(() => useBudgets({ month: 1, year: 2026 }));
+    await waitFor(() => {
+      expect(api.getBudgets).toHaveBeenCalledTimes(1);
+    });
+    api.getBudgets.mockResolvedValue([{ kategoria: 'Transport', kwota: 500 }]);
+    await act(async () => {
+      await result.current.refresh();
+    });
+    expect(api.getBudgets).toHaveBeenCalledTimes(2);
+    expect(result.current.budgets).toEqual([{ kategoria: 'Transport', kwota: 500 }]);
+  });
+});

--- a/src/hooks/__tests__/useMonthlyData.test.js
+++ b/src/hooks/__tests__/useMonthlyData.test.js
@@ -1,0 +1,112 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { renderHook, waitFor, act } from '@testing-library/react';
+
+vi.mock('../../services/api', () => ({
+  getAllData: vi.fn(),
+}));
+vi.mock('../../utils/logger', () => ({
+  logger: { warn: vi.fn(), error: vi.fn(), info: vi.fn(), debug: vi.fn() },
+}));
+
+import * as api from '../../services/api';
+import { logger } from '../../utils/logger';
+import { useMonthlyData } from '../useMonthlyData';
+
+const setOnline = (online) => {
+  Object.defineProperty(navigator, 'onLine', {
+    configurable: true,
+    get: () => online,
+  });
+};
+
+describe('useMonthlyData', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    setOnline(true);
+  });
+
+  afterEach(() => {
+    setOnline(true);
+  });
+
+  it('pobiera dane i wypełnia stan', async () => {
+    api.getAllData.mockResolvedValue({
+      transakcje: [{ id: '1', kwota: 10 }],
+      kategorie: { Wydatek: { Jedzenie: ['Lidl'] }, Przychód: {} },
+      osoby: ['Jan'],
+    });
+
+    const { result } = renderHook(() => useMonthlyData({ month: 2, year: 2026 }));
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+    expect(result.current.transakcje).toEqual([{ id: '1', kwota: 10 }]);
+    expect(result.current.kategorie).toEqual({ Wydatek: { Jedzenie: ['Lidl'] }, Przychód: {} });
+    expect(result.current.osoby).toEqual(['Jan']);
+    expect(result.current.error).toBeNull();
+    expect(api.getAllData).toHaveBeenCalledWith(2, 2026);
+  });
+
+  it('ustawia error i puste dane gdy offline', async () => {
+    setOnline(false);
+    const { result } = renderHook(() => useMonthlyData({ month: 1, year: 2026 }));
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+    expect(result.current.error).toMatch(/połączenia/i);
+    expect(api.getAllData).not.toHaveBeenCalled();
+  });
+
+  it('ustawia error i loguje przy wyjątku API', async () => {
+    api.getAllData.mockRejectedValue(new Error('500'));
+    const { result } = renderHook(() => useMonthlyData({ month: 1, year: 2026 }));
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+    expect(result.current.error).toMatch(/Nie udało się/);
+    expect(logger.error).toHaveBeenCalled();
+  });
+
+  it('nie pobiera danych gdy enabled=false', () => {
+    renderHook(() => useMonthlyData({ month: 1, year: 2026, enabled: false }));
+    expect(api.getAllData).not.toHaveBeenCalled();
+  });
+
+  it('odpornie traktuje brak pól w odpowiedzi API', async () => {
+    api.getAllData.mockResolvedValue({});
+    const { result } = renderHook(() => useMonthlyData({ month: 1, year: 2026 }));
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+    expect(result.current.transakcje).toEqual([]);
+    expect(result.current.kategorie).toEqual({ Wydatek: {}, Przychód: {} });
+    expect(result.current.osoby).toEqual([]);
+  });
+
+  it('setTransakcje pozwala na optimistic update', async () => {
+    api.getAllData.mockResolvedValue({ transakcje: [], kategorie: {}, osoby: [] });
+    const { result } = renderHook(() => useMonthlyData({ month: 1, year: 2026 }));
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+    act(() => {
+      result.current.setTransakcje([{ id: 'x', kwota: 99 }]);
+    });
+    expect(result.current.transakcje).toEqual([{ id: 'x', kwota: 99 }]);
+  });
+
+  it('refresh(false) nie pokazuje spinnera', async () => {
+    api.getAllData.mockResolvedValue({ transakcje: [], kategorie: {}, osoby: [] });
+    const { result } = renderHook(() => useMonthlyData({ month: 1, year: 2026 }));
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+    let pending;
+    await act(async () => {
+      pending = result.current.refresh(false);
+      await pending;
+    });
+    expect(result.current.isLoading).toBe(false);
+  });
+});

--- a/src/hooks/__tests__/usePendingOperations.test.js
+++ b/src/hooks/__tests__/usePendingOperations.test.js
@@ -1,0 +1,98 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { renderHook, waitFor, act } from '@testing-library/react';
+
+vi.mock('../../services/offlineQueue', () => ({
+  getQueuedOperations: vi.fn(),
+  processQueue: vi.fn(),
+}));
+
+import { getQueuedOperations, processQueue } from '../../services/offlineQueue';
+import { usePendingOperations } from '../usePendingOperations';
+
+describe('usePendingOperations', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    getQueuedOperations.mockReturnValue([]);
+  });
+
+  it('zwraca początkową liczbę oczekujących operacji', () => {
+    getQueuedOperations.mockReturnValue([{}, {}, {}]);
+    const { result } = renderHook(() =>
+      usePendingOperations({ isOffline: false, onSynced: vi.fn(), addToast: vi.fn() })
+    );
+    expect(result.current.pendingCount).toBe(3);
+    expect(result.current.isSyncing).toBe(false);
+  });
+
+  it('nie uruchamia sync gdy zawsze online (żadna zmiana offline→online)', async () => {
+    const { result } = renderHook(() =>
+      usePendingOperations({ isOffline: false, onSynced: vi.fn(), addToast: vi.fn() })
+    );
+    await new Promise(r => setTimeout(r, 0));
+    expect(processQueue).not.toHaveBeenCalled();
+    expect(result.current.isSyncing).toBe(false);
+  });
+
+  it('uruchamia processQueue po zmianie offline→online z niepustą kolejką', async () => {
+    getQueuedOperations.mockReturnValue([{ id: 1 }, { id: 2 }]);
+    processQueue.mockResolvedValue({ succeeded: 2, failed: 0 });
+    const onSynced = vi.fn().mockResolvedValue();
+    const addToast = vi.fn();
+
+    const { rerender, result } = renderHook(
+      ({ isOffline }) => usePendingOperations({ isOffline, onSynced, addToast }),
+      { initialProps: { isOffline: true } }
+    );
+
+    rerender({ isOffline: false });
+
+    await waitFor(() => {
+      expect(processQueue).toHaveBeenCalled();
+    });
+    await waitFor(() => {
+      expect(onSynced).toHaveBeenCalled();
+    });
+    expect(addToast).toHaveBeenCalledWith(expect.stringContaining('2'));
+    expect(result.current.pendingCount).toBe(0);
+  });
+
+  it('nie uruchamia sync gdy kolejka jest pusta po powrocie online', async () => {
+    getQueuedOperations.mockReturnValue([]);
+    const { rerender } = renderHook(
+      ({ isOffline }) => usePendingOperations({ isOffline, onSynced: vi.fn(), addToast: vi.fn() }),
+      { initialProps: { isOffline: true } }
+    );
+    rerender({ isOffline: false });
+    await new Promise(r => setTimeout(r, 10));
+    expect(processQueue).not.toHaveBeenCalled();
+  });
+
+  it('wyświetla toast błędu gdy część operacji nie powiodła się', async () => {
+    getQueuedOperations.mockReturnValue([{ id: 1 }, { id: 2 }]);
+    processQueue.mockResolvedValue({ succeeded: 1, failed: 1 });
+    const addToast = vi.fn();
+
+    const { rerender } = renderHook(
+      ({ isOffline }) => usePendingOperations({ isOffline, onSynced: vi.fn(), addToast }),
+      { initialProps: { isOffline: true } }
+    );
+    rerender({ isOffline: false });
+
+    await waitFor(() => {
+      expect(addToast).toHaveBeenCalledWith(expect.stringContaining('1'), 'error');
+    });
+  });
+
+  it('refreshPendingCount aktualizuje licznik z aktualnego stanu kolejki', () => {
+    getQueuedOperations.mockReturnValue([]);
+    const { result } = renderHook(() =>
+      usePendingOperations({ isOffline: false, onSynced: vi.fn(), addToast: vi.fn() })
+    );
+    expect(result.current.pendingCount).toBe(0);
+    getQueuedOperations.mockReturnValue([{}, {}]);
+    act(() => {
+      result.current.refreshPendingCount();
+    });
+    expect(result.current.pendingCount).toBe(2);
+  });
+});

--- a/src/hooks/__tests__/useYearlyData.test.js
+++ b/src/hooks/__tests__/useYearlyData.test.js
@@ -1,0 +1,189 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { renderHook, waitFor, act } from '@testing-library/react';
+
+vi.mock('../../services/api', () => ({
+  getTransakcjeForYear: vi.fn(),
+  getAvailableYears: vi.fn(),
+}));
+
+import * as api from '../../services/api';
+import { useYearlyData } from '../useYearlyData';
+
+const mkTx = (id, month, typ, kwota, kategoria = 'Jedzenie', osoba = 'Jan') => ({
+  id: String(id),
+  data: `2026-${String(month).padStart(2, '0')}-15`,
+  typ,
+  kwota,
+  kategoria,
+  osoba,
+});
+
+describe('useYearlyData', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    api.getAvailableYears.mockResolvedValue([2026, 2025, 2024]);
+  });
+
+  it('ładuje dane bieżącego i poprzedniego roku oraz listę lat', async () => {
+    api.getTransakcjeForYear.mockImplementation(year => {
+      if (year === 2026) return Promise.resolve([mkTx(1, 1, 'Przychód', 1000)]);
+      if (year === 2025) return Promise.resolve([mkTx(2, 1, 'Przychód', 500)]);
+      return Promise.resolve([]);
+    });
+
+    const { result } = renderHook(() => useYearlyData(2026));
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+    expect(result.current.availableYears).toEqual([2026, 2025, 2024]);
+    expect(result.current.totalIncome).toBe(1000);
+    expect(result.current.monthlyData).toHaveLength(12);
+  });
+
+  it('oblicza YoY na podstawie danych z poprzedniego roku', async () => {
+    api.getTransakcjeForYear.mockImplementation(year => {
+      if (year === 2026) return Promise.resolve([mkTx(1, 1, 'Przychód', 1000)]);
+      if (year === 2025) return Promise.resolve([mkTx(2, 1, 'Przychód', 500)]);
+      return Promise.resolve([]);
+    });
+    const { result } = renderHook(() => useYearlyData(2026));
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+    expect(result.current.yoyIncome.change).toBe(500);
+    expect(result.current.yoyIncome.percent).toBe(100);
+  });
+
+  it('oblicza totalBalance i avgMonthlyExpense', async () => {
+    api.getTransakcjeForYear.mockImplementation(year => {
+      if (year === 2026) return Promise.resolve([
+        mkTx(1, 1, 'Przychód', 1200),
+        mkTx(2, 1, 'Wydatek', 600),
+      ]);
+      return Promise.resolve([]);
+    });
+    const { result } = renderHook(() => useYearlyData(2026));
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+    expect(result.current.totalIncome).toBe(1200);
+    expect(result.current.totalExpenses).toBe(600);
+    expect(result.current.totalBalance).toBe(600);
+    expect(result.current.avgMonthlyExpense).toBe(50);
+  });
+
+  it('ustawia puste tablice gdy fetch się nie powiedzie', async () => {
+    api.getTransakcjeForYear.mockRejectedValue(new Error('boom'));
+    const { result } = renderHook(() => useYearlyData(2026));
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+    expect(result.current.yearData).toEqual([]);
+    expect(result.current.prevYearData).toEqual([]);
+  });
+
+  it('nie pobiera compareData dopóki compareYear jest null', async () => {
+    api.getTransakcjeForYear.mockResolvedValue([]);
+    const { result } = renderHook(() => useYearlyData(2026));
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+    expect(result.current.compareYear).toBeNull();
+    expect(result.current.compareChartData).toEqual([]);
+    expect(result.current.categoryCompareTable).toEqual([]);
+    // Pierwszy fetch: rok bieżący + poprzedni = 2 wywołania
+    expect(api.getTransakcjeForYear).toHaveBeenCalledTimes(2);
+  });
+
+  it('pobiera compareData po ustawieniu compareYear i buduje compareChartData', async () => {
+    api.getTransakcjeForYear.mockImplementation(year => {
+      if (year === 2026) return Promise.resolve([mkTx(1, 2, 'Wydatek', 300)]);
+      if (year === 2024) return Promise.resolve([mkTx(2, 2, 'Wydatek', 200)]);
+      return Promise.resolve([]);
+    });
+    const { result } = renderHook(() => useYearlyData(2026));
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    act(() => {
+      result.current.setCompareYear(2024);
+    });
+
+    await waitFor(() => {
+      expect(result.current.compareTotalExpenses).toBe(200);
+    });
+    expect(result.current.compareChartData).toHaveLength(12);
+    const feb = result.current.compareChartData[1];
+    expect(feb['Wydatki 2026']).toBe(300);
+    expect(feb['Wydatki 2024']).toBe(200);
+  });
+
+  it('buduje categoryCompareTable z odpowiednim sortowaniem i zmianą', async () => {
+    api.getTransakcjeForYear.mockImplementation(year => {
+      if (year === 2026) return Promise.resolve([
+        mkTx(1, 1, 'Wydatek', 500, 'Jedzenie'),
+        mkTx(2, 1, 'Wydatek', 100, 'Transport'),
+      ]);
+      if (year === 2024) return Promise.resolve([
+        mkTx(3, 1, 'Wydatek', 300, 'Jedzenie'),
+        mkTx(4, 1, 'Wydatek', 50, 'Rozrywka'),
+      ]);
+      return Promise.resolve([]);
+    });
+    const { result } = renderHook(() => useYearlyData(2026));
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+    act(() => {
+      result.current.setCompareYear(2024);
+    });
+    await waitFor(() => {
+      expect(result.current.compareTotalExpenses).toBe(350);
+    });
+    const table = result.current.categoryCompareTable;
+    expect(table[0].name).toBe('Jedzenie');
+    expect(table[0].base).toBe(500);
+    expect(table[0].compare).toBe(300);
+    expect(table[0].change).toBe(200);
+    const rozrywka = table.find(r => r.name === 'Rozrywka');
+    expect(rozrywka).toEqual({ name: 'Rozrywka', base: 0, compare: 50, change: -50 });
+  });
+
+  it('cumulativeSavings kumuluje różnicę przychody-wydatki po miesiącach', async () => {
+    api.getTransakcjeForYear.mockImplementation(year => {
+      if (year === 2026) return Promise.resolve([
+        mkTx(1, 1, 'Przychód', 1000),
+        mkTx(2, 1, 'Wydatek', 400),
+        mkTx(3, 2, 'Przychód', 500),
+        mkTx(4, 2, 'Wydatek', 200),
+      ]);
+      return Promise.resolve([]);
+    });
+    const { result } = renderHook(() => useYearlyData(2026));
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+    expect(result.current.cumulativeSavings[0].savings).toBe(600);
+    expect(result.current.cumulativeSavings[1].savings).toBe(900);
+    expect(result.current.cumulativeSavings[11].savings).toBe(900);
+  });
+
+  it('resetuje compareYear przy zmianie roku bazowego', async () => {
+    api.getTransakcjeForYear.mockResolvedValue([]);
+    const { result, rerender } = renderHook(({ year }) => useYearlyData(year), {
+      initialProps: { year: 2026 },
+    });
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+    act(() => {
+      result.current.setCompareYear(2024);
+    });
+    rerender({ year: 2025 });
+    await waitFor(() => {
+      expect(result.current.compareYear).toBeNull();
+    });
+  });
+});

--- a/src/hooks/__tests__/useYearlyViewHint.test.js
+++ b/src/hooks/__tests__/useYearlyViewHint.test.js
@@ -1,0 +1,56 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { useYearlyViewHint } from '../useYearlyViewHint';
+
+const STORAGE_KEY = 'yearlyViewHintSeen';
+
+describe('useYearlyViewHint', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('pokazuje hint i pulse przy pierwszym uruchomieniu', () => {
+    const { result } = renderHook(() => useYearlyViewHint());
+    expect(result.current.showHint).toBe(true);
+    expect(result.current.pulseActive).toBe(true);
+  });
+
+  it('nie pokazuje hintu gdy flaga w localStorage jest ustawiona', () => {
+    localStorage.setItem(STORAGE_KEY, 'true');
+    const { result } = renderHook(() => useYearlyViewHint());
+    expect(result.current.showHint).toBe(false);
+    expect(result.current.pulseActive).toBe(false);
+  });
+
+  it('wyłącza pulse po 5 sekundach', () => {
+    const { result } = renderHook(() => useYearlyViewHint());
+    expect(result.current.pulseActive).toBe(true);
+    act(() => {
+      vi.advanceTimersByTime(5000);
+    });
+    expect(result.current.pulseActive).toBe(false);
+    expect(result.current.showHint).toBe(true);
+  });
+
+  it('dismissHint ukrywa hint, wyłącza pulse i zapisuje w localStorage', () => {
+    const { result } = renderHook(() => useYearlyViewHint());
+    act(() => {
+      result.current.dismissHint();
+    });
+    expect(result.current.showHint).toBe(false);
+    expect(result.current.pulseActive).toBe(false);
+    expect(localStorage.getItem(STORAGE_KEY)).toBe('true');
+  });
+
+  it('dismissHint jest stabilny między renderami', () => {
+    const { result, rerender } = renderHook(() => useYearlyViewHint());
+    const first = result.current.dismissHint;
+    rerender();
+    expect(result.current.dismissHint).toBe(first);
+  });
+});

--- a/src/hooks/useAvailableYears.js
+++ b/src/hooks/useAvailableYears.js
@@ -1,0 +1,23 @@
+import { useEffect, useState } from 'react';
+import * as api from '../services/api';
+
+// Fetch available years for the yearly summary view. Falls back to the
+// current year on error or when disabled.
+export function useAvailableYears({ enabled = true } = {}) {
+  const [availableYears, setAvailableYears] = useState([new Date().getFullYear()]);
+
+  useEffect(() => {
+    if (!enabled) return;
+    let cancelled = false;
+    api.getAvailableYears()
+      .then(years => {
+        if (!cancelled) setAvailableYears(years);
+      })
+      .catch(() => {});
+    return () => {
+      cancelled = true;
+    };
+  }, [enabled]);
+
+  return availableYears;
+}

--- a/src/hooks/useBudgets.js
+++ b/src/hooks/useBudgets.js
@@ -1,0 +1,23 @@
+import { useCallback, useEffect, useState } from 'react';
+import * as api from '../services/api';
+import { logger } from '../utils/logger';
+
+export function useBudgets({ month, year, enabled = true }) {
+  const [budgets, setBudgets] = useState([]);
+
+  const refresh = useCallback(async () => {
+    try {
+      const data = await api.getBudgets(month, year);
+      setBudgets(Array.isArray(data) ? data : []);
+    } catch (err) {
+      logger.warn('useBudgets', 'Nie udało się pobrać budżetów', err);
+    }
+  }, [month, year]);
+
+  useEffect(() => {
+    if (!enabled) return;
+    refresh();
+  }, [enabled, refresh]);
+
+  return { budgets, refresh };
+}

--- a/src/hooks/useMonthlyData.js
+++ b/src/hooks/useMonthlyData.js
@@ -1,0 +1,56 @@
+import { useCallback, useEffect, useState } from 'react';
+import * as api from '../services/api';
+import { logger } from '../utils/logger';
+
+// Owns state for transakcje + kategorie + osoby + isLoading + error and
+// fetches them for the given period. Setters are exposed so callers can
+// perform optimistic updates (CRUD) and settings panels can push changes
+// back into state without a round-trip.
+export function useMonthlyData({ month, year, enabled = true }) {
+  const [transakcje, setTransakcje] = useState([]);
+  const [kategorie, setKategorie] = useState({ Wydatek: {}, Przychód: {} });
+  const [osoby, setOsoby] = useState([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState(null);
+
+  const refresh = useCallback(async (showSpinner = true) => {
+    if (showSpinner) setIsLoading(true);
+    setError(null);
+
+    if (!navigator.onLine) {
+      setError('Brak połączenia z internetem.');
+      setIsLoading(false);
+      return;
+    }
+
+    try {
+      const data = await api.getAllData(month, year);
+      setTransakcje(Array.isArray(data.transakcje) ? data.transakcje : []);
+      setKategorie(data.kategorie || { Wydatek: {}, Przychód: {} });
+      setOsoby(Array.isArray(data.osoby) ? data.osoby : []);
+    } catch (err) {
+      setError('Nie udało się pobrać danych. Sprawdź połączenie i odśwież stronę.');
+      logger.error('useMonthlyData', err);
+    } finally {
+      setIsLoading(false);
+    }
+  }, [month, year]);
+
+  useEffect(() => {
+    if (!enabled) return;
+    refresh();
+  }, [enabled, refresh]);
+
+  return {
+    transakcje,
+    kategorie,
+    osoby,
+    isLoading,
+    error,
+    setTransakcje,
+    setKategorie,
+    setOsoby,
+    setError,
+    refresh,
+  };
+}

--- a/src/hooks/usePendingOperations.js
+++ b/src/hooks/usePendingOperations.js
@@ -1,0 +1,56 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { getQueuedOperations, processQueue } from '../services/offlineQueue';
+
+// Tracks offline queue size and auto-syncs when connectivity is restored.
+// `onSynced` is called after a successful flush so the caller can re-fetch
+// server-side state. Callbacks are captured via refs so identity changes
+// don't re-run the sync effect.
+export function usePendingOperations({ isOffline, onSynced, addToast }) {
+  const [pendingCount, setPendingCount] = useState(() => getQueuedOperations().length);
+  const [isSyncing, setIsSyncing] = useState(false);
+  const wasOfflineRef = useRef(isOffline);
+
+  const onSyncedRef = useRef(onSynced);
+  const addToastRef = useRef(addToast);
+  useEffect(() => { onSyncedRef.current = onSynced; }, [onSynced]);
+  useEffect(() => { addToastRef.current = addToast; }, [addToast]);
+
+  useEffect(() => {
+    if (wasOfflineRef.current && !isOffline) {
+      const syncQueue = async () => {
+        const queue = getQueuedOperations();
+        if (queue.length === 0) {
+          wasOfflineRef.current = false;
+          return;
+        }
+        setIsSyncing(true);
+        try {
+          const result = await processQueue();
+          if (result.succeeded > 0) {
+            addToastRef.current?.(
+              `Zsynchronizowano ${result.succeeded} ${result.succeeded === 1 ? 'operację' : 'operacji'}`
+            );
+          }
+          if (result.failed > 0) {
+            addToastRef.current?.(
+              `Nie udało się zsynchronizować ${result.failed} operacji`,
+              'error'
+            );
+          }
+          setPendingCount(0);
+          await onSyncedRef.current?.();
+        } finally {
+          setIsSyncing(false);
+        }
+      };
+      syncQueue();
+    }
+    wasOfflineRef.current = isOffline;
+  }, [isOffline]);
+
+  const refreshPendingCount = useCallback(() => {
+    setPendingCount(getQueuedOperations().length);
+  }, []);
+
+  return { pendingCount, isSyncing, refreshPendingCount };
+}

--- a/src/hooks/useYearlyData.js
+++ b/src/hooks/useYearlyData.js
@@ -1,0 +1,164 @@
+import { useEffect, useMemo, useState } from 'react';
+import * as api from '../services/api';
+import {
+  MONTHS_PL_SHORT,
+  aggregateByMonth,
+  aggregateByCategory,
+  aggregateByPerson,
+  calculateYoY,
+} from '../utils/calculations';
+
+// Single hook that owns all data-fetching + derived computations for the
+// yearly summary view. Returning everything as a flat object keeps the
+// rendering component focused on layout and keeps recharts/jsx separate
+// from data logic.
+export function useYearlyData(year) {
+  const [yearData, setYearData] = useState([]);
+  const [prevYearData, setPrevYearData] = useState([]);
+  const [compareYear, setCompareYear] = useState(null);
+  const [compareData, setCompareData] = useState([]);
+  const [availableYears, setAvailableYears] = useState([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [isLoadingCompare, setIsLoadingCompare] = useState(false);
+
+  // Fetch base year + prev year + available years list
+  useEffect(() => {
+    let cancelled = false;
+    setIsLoading(true);
+    setCompareYear(null);
+    setCompareData([]);
+
+    (async () => {
+      try {
+        const [data, prevData, years] = await Promise.all([
+          api.getTransakcjeForYear(year),
+          api.getTransakcjeForYear(year - 1).catch(() => []),
+          api.getAvailableYears().catch(() => [year]),
+        ]);
+        if (cancelled) return;
+        setYearData(data || []);
+        setPrevYearData(prevData || []);
+        setAvailableYears(years);
+      } catch {
+        if (!cancelled) {
+          setYearData([]);
+          setPrevYearData([]);
+        }
+      } finally {
+        if (!cancelled) setIsLoading(false);
+      }
+    })();
+
+    return () => { cancelled = true; };
+  }, [year]);
+
+  // Fetch compare year on demand
+  useEffect(() => {
+    if (!compareYear) { setCompareData([]); return; }
+    let cancelled = false;
+    setIsLoadingCompare(true);
+    api.getTransakcjeForYear(compareYear)
+      .then(data => { if (!cancelled) setCompareData(data || []); })
+      .catch(() => { if (!cancelled) setCompareData([]); })
+      .finally(() => { if (!cancelled) setIsLoadingCompare(false); });
+    return () => { cancelled = true; };
+  }, [compareYear]);
+
+  // Derived — base year
+  const monthlyData = useMemo(() => aggregateByMonth(yearData), [yearData]);
+  const totalIncome = useMemo(() => monthlyData.reduce((s, m) => s + m.przychody, 0), [monthlyData]);
+  const totalExpenses = useMemo(() => monthlyData.reduce((s, m) => s + m.wydatki, 0), [monthlyData]);
+  const totalBalance = totalIncome - totalExpenses;
+  const avgMonthlyExpense = totalExpenses / 12;
+
+  const cumulativeSavings = useMemo(() => {
+    let cum = 0;
+    return monthlyData.map(m => {
+      cum += (m.przychody - m.wydatki);
+      return { month: m.month, savings: Math.round(cum * 100) / 100 };
+    });
+  }, [monthlyData]);
+
+  const categoryData = useMemo(() => aggregateByCategory(yearData, 'Wydatek'), [yearData]);
+  const personData = useMemo(() => aggregateByPerson(yearData), [yearData]);
+  const personPieData = useMemo(
+    () => personData.map(p => ({ name: p.name, value: p.wydatki })).filter(p => p.value > 0),
+    [personData]
+  );
+  const maxCategoryValue = categoryData.length > 0 ? categoryData[0].value : 1;
+
+  // Derived — previous year (for YoY)
+  const prevMonthlyData = useMemo(() => aggregateByMonth(prevYearData), [prevYearData]);
+  const prevTotalIncome = useMemo(() => prevMonthlyData.reduce((s, m) => s + m.przychody, 0), [prevMonthlyData]);
+  const prevTotalExpenses = useMemo(() => prevMonthlyData.reduce((s, m) => s + m.wydatki, 0), [prevMonthlyData]);
+  const prevTotalBalance = prevTotalIncome - prevTotalExpenses;
+  const yoyIncome = useMemo(() => calculateYoY(totalIncome, prevTotalIncome), [totalIncome, prevTotalIncome]);
+  const yoyExpenses = useMemo(() => calculateYoY(totalExpenses, prevTotalExpenses), [totalExpenses, prevTotalExpenses]);
+  const yoyBalance = useMemo(() => calculateYoY(totalBalance, prevTotalBalance), [totalBalance, prevTotalBalance]);
+
+  // Derived — compare year
+  const compareMonthlyData = useMemo(() => aggregateByMonth(compareData), [compareData]);
+  const compareCategoryData = useMemo(() => aggregateByCategory(compareData, 'Wydatek'), [compareData]);
+  const compareTotalIncome = useMemo(() => compareMonthlyData.reduce((s, m) => s + m.przychody, 0), [compareMonthlyData]);
+  const compareTotalExpenses = useMemo(() => compareMonthlyData.reduce((s, m) => s + m.wydatki, 0), [compareMonthlyData]);
+
+  const compareChartData = useMemo(() => {
+    if (!compareYear) return [];
+    return MONTHS_PL_SHORT.map((m, i) => ({
+      month: m,
+      [`Wydatki ${year}`]: monthlyData[i].wydatki,
+      [`Wydatki ${compareYear}`]: compareMonthlyData[i].wydatki,
+      [`Przychody ${year}`]: monthlyData[i].przychody,
+      [`Przychody ${compareYear}`]: compareMonthlyData[i].przychody,
+    }));
+  }, [compareYear, year, monthlyData, compareMonthlyData]);
+
+  const categoryCompareTable = useMemo(() => {
+    if (!compareYear) return [];
+    const map = new Map();
+    categoryData.forEach(c => map.set(c.name, { base: c.value, compare: 0 }));
+    compareCategoryData.forEach(c => {
+      if (map.has(c.name)) map.get(c.name).compare = c.value;
+      else map.set(c.name, { base: 0, compare: c.value });
+    });
+    return Array.from(map.entries())
+      .map(([name, { base, compare }]) => ({ name, base, compare, change: base - compare }))
+      .sort((a, b) => b.base - a.base);
+  }, [compareYear, categoryData, compareCategoryData]);
+
+  return {
+    // raw state
+    yearData,
+    prevYearData,
+    availableYears,
+    compareYear,
+    setCompareYear,
+    isLoading,
+    isLoadingCompare,
+
+    // base year totals + aggregations
+    monthlyData,
+    totalIncome,
+    totalExpenses,
+    totalBalance,
+    avgMonthlyExpense,
+    cumulativeSavings,
+    categoryData,
+    personData,
+    personPieData,
+    maxCategoryValue,
+
+    // YoY
+    yoyIncome,
+    yoyExpenses,
+    yoyBalance,
+
+    // compare
+    compareMonthlyData,
+    compareCategoryData,
+    compareTotalIncome,
+    compareTotalExpenses,
+    compareChartData,
+    categoryCompareTable,
+  };
+}

--- a/src/hooks/useYearlyViewHint.js
+++ b/src/hooks/useYearlyViewHint.js
@@ -1,0 +1,25 @@
+import { useCallback, useEffect, useState } from 'react';
+
+const STORAGE_KEY = 'yearlyViewHintSeen';
+const PULSE_TIMEOUT_MS = 5000;
+
+// First-time visual hint for the yearly-view toggle: persists a flag in
+// localStorage so the hint and pulse animation only appear once per device.
+export function useYearlyViewHint() {
+  const [showHint, setShowHint] = useState(() => !localStorage.getItem(STORAGE_KEY));
+  const [pulseActive, setPulseActive] = useState(() => !localStorage.getItem(STORAGE_KEY));
+
+  useEffect(() => {
+    if (!pulseActive) return;
+    const timer = setTimeout(() => setPulseActive(false), PULSE_TIMEOUT_MS);
+    return () => clearTimeout(timer);
+  }, [pulseActive]);
+
+  const dismissHint = useCallback(() => {
+    setShowHint(false);
+    setPulseActive(false);
+    localStorage.setItem(STORAGE_KEY, 'true');
+  }, []);
+
+  return { showHint, pulseActive, dismissHint };
+}


### PR DESCRIPTION
## Podsumowanie

- `YearlySummary.jsx` zredukowany z 543 → ~90 linii (tylko nawigacja zakładek + dispatcher do komponentów).
- Zakładki wyodrębnione do osobnych plików: `OverviewTab`, `CompareTab`, `PersonsTab` + wspólne `primitives` (ikony, tooltipy, `KpiCard`, paleta kolorów).
- Dodano testy jednostkowe dla wszystkich wcześniej wyodrębnionych hooków: `useYearlyViewHint`, `useAvailableYears`, `useBudgets`, `useMonthlyData`, `usePendingOperations`, `useYearlyData` (+39 testów).

## Zmiany plików

- **Nowe:** `src/components/yearly/{primitives,OverviewTab,CompareTab,PersonsTab}.jsx`
- **Nowe testy:** `src/hooks/__tests__/{useYearlyViewHint,useAvailableYears,useBudgets,useMonthlyData,usePendingOperations,useYearlyData}.test.js`
- **Zmodyfikowane:** `src/components/YearlySummary.jsx`

## Test plan

- [x] `npm test -- --run` — 244 testy pass (205 poprzednich + 39 nowych)
- [x] `npm run build` — produkcyjny build OK
- [ ] Ręczna weryfikacja w przeglądarce: przełączanie zakładek Przegląd / Porównanie lat / Osoby
- [ ] Ręczna weryfikacja: wybór roku do porównania, stan ładowania, tabela kategorii
- [ ] Ręczna weryfikacja: widok osób z przychodami/wydatkami i pie chart udziałów

https://claude.ai/code/session_01RA2m3RcsnnebQeViwDZyee