### PR TITLE
feat(auth): migracja z Google OAuth na Supabase Auth (email+hasło)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,7 +1,6 @@
 VITE_SUPABASE_URL=https://twoj-projekt.supabase.co
 VITE_SUPABASE_ANON_KEY=twoj-anon-key
 VITE_HOUSEHOLD_ID=twoj-household-uuid
-VITE_GOOGLE_CLIENT_ID=TWOJ_GOOGLE_CLIENT_ID.apps.googleusercontent.com
 
 # ── AI kategoryzacja (opcjonalnie) ──────────────────────────────────────────
 # OPENAI_API_KEY — klucz zostaje wyłącznie po stronie serwera (Vercel).

--- a/README.md
+++ b/README.md
@@ -70,7 +70,6 @@ Uzupełnij plik `.env`:
 VITE_SUPABASE_URL=https://twoj-projekt.supabase.co
 VITE_SUPABASE_ANON_KEY=twoj-anon-key
 VITE_HOUSEHOLD_ID=twoj-household-uuid
-VITE_GOOGLE_CLIENT_ID=TWOJ_CLIENT_ID.apps.googleusercontent.com
 
 # Opcjonalnie — włącza kategoryzację AI podczas importu CSV
 VITE_OPENAI_API_KEY=sk-...
@@ -87,11 +86,16 @@ migration/001_create_budzety.sql
 migration/002_rls_policies_phase2.sql
 migration/003_authentication_phase3.sql
 migration/004_category_embeddings.sql   ← pgvector + AI kategoryzacja
+migration/005_email_password_auth.sql   ← Supabase Auth email+hasło
 ```
 
 > Przed uruchomieniem migracji 004 włącz rozszerzenie **pgvector** w Supabase Dashboard → Database → Extensions.
 
-### 5. Skonfiguruj autoryzację Google OAuth
+### 5. Skonfiguruj autoryzację (Supabase Auth — email + hasło)
+
+W Supabase Dashboard:
+- **Authentication → Providers → Email**: *Enable email signup: ON*, *Confirm email: ON*.
+- **Authentication → Providers → Google**: *OFF* (nie używamy).
 
 Szczegółowa instrukcja: [docs/SETUP_AUTH_PHASE3.md](./docs/SETUP_AUTH_PHASE3.md)
 
@@ -262,7 +266,6 @@ budget-app/
 | `VITE_SUPABASE_URL` | ✅ | URL projektu Supabase |
 | `VITE_SUPABASE_ANON_KEY` | ✅ | Klucz anonimowy Supabase |
 | `VITE_HOUSEHOLD_ID` | ⚠️ | UUID gospodarstwa (fallback bez auth) |
-| `VITE_GOOGLE_CLIENT_ID` | ✅ | Client ID Google OAuth 2.0 |
 | `VITE_OPENAI_API_KEY` | ➕ | Klucz OpenAI — włącza kategoryzację AI |
 
 ## Deployment

--- a/docs/SETUP_AUTH_PHASE3.md
+++ b/docs/SETUP_AUTH_PHASE3.md
@@ -1,154 +1,118 @@
-# Faza 3: Autentykacja — Setup Guide
+# Autentykacja — Setup Guide
 
 ## Przegląd
 
-Faza 3 zabezpiecza aplikację poprzez Supabase Auth (Google OAuth) i Row Level Security (RLS). Użytkownicy będą się logować przez Google, a dane będą dostępne tylko dla członków ich gospodarstwa (household).
+Aplikacja używa **Supabase Auth** z logowaniem przez **email + hasło**. Row Level Security (RLS) ogranicza dostęp do danych wyłącznie do członków tego samego gospodarstwa (`household`).
 
-## Kroki Setup'u
+> Historyczna uwaga: wcześniejsza wersja (Phase 3) używała Google OAuth przez Google Identity Services. Migracja na Supabase Auth została wykonana w `migration/005_email_password_auth.sql`.
 
-### 1. Włączenie Google OAuth w Supabase Dashboard
+## Kroki Setupu
 
-1. Wejdź do [Supabase Dashboard](https://supabase.com/dashboard)
-2. Wybierz projekt
-3. **Authentication → Providers → Google**
-4. Zmień status na **Enabled**
-5. Skopiuj **Client ID** i **Client Secret** (zdobędziesz je w kroku 2)
+### 1. Włączenie Email provider w Supabase Dashboard
 
-### 2. Konfiguracja Google Cloud Console
+1. Wejdź do [Supabase Dashboard](https://supabase.com/dashboard) → wybierz projekt.
+2. **Authentication → Providers → Email**:
+   - **Enable email signup:** ON
+   - **Confirm email:** ON (wymagane — patrz sekcja bezpieczeństwo)
+3. **Authentication → Providers → Google:** OFF (nie używamy).
 
-1. Wejdź do [Google Cloud Console](https://console.cloud.google.com)
-2. Utwórz nowy projekt lub wybierz istniejący
-3. **API & Services → Credentials**
-4. **Create Credentials → OAuth 2.0 Client ID**
-5. Typ: **Web application**
-6. **Authorized JavaScript origins** (dodaj):
-   - `http://localhost:5173` (development)
-   - `http://localhost:3000` (development alt)
-7. **Authorized redirect URIs** (dodaj):
-   - `https://YOUR_SUPABASE_PROJECT.supabase.co/auth/v1/callback` (production)
-   - `http://localhost:5173/auth/v1/callback` (development)
-8. Skopiuj wygenerowany **Client ID** i **Client Secret**
-
-### 3. Wklejanie credentials do Supabase
-
-W Supabase Dashboard → **Authentication → Providers → Google**:
-- Wklej **Client ID** z Google Cloud
-- Wklej **Client Secret** z Google Cloud
-- Kliknij **Save**
-
-### 4. Konfiguracja Redirect URLs w Supabase
+### 2. Konfiguracja URL Configuration
 
 **Authentication → URL Configuration:**
-- **Site URL:** `https://YOUR_DOMAIN.vercel.app` (production) lub `http://localhost:5173` (dev)
-- **Redirect URLs:** Dodaj obie:
-  - `http://localhost:5173/` (development)
-  - `https://YOUR_DOMAIN.vercel.app/` (production)
+- **Site URL:** `http://localhost:5173` (dev) lub `https://YOUR_DOMAIN.vercel.app` (prod).
+- **Redirect URLs:** dodaj oba warianty z i bez końcowego slasha.
 
-### 5. Zmienne środowiskowe (.env.local)
+### 3. Szablony email (opcjonalnie, po polsku)
 
-Zaktualizuj `.env.local` z:
+**Authentication → Email Templates** — przetłumacz:
+- **Confirm signup** — link potwierdzający rejestrację.
+- **Reset password** — link do resetu hasła.
+
+### 4. Zmienne środowiskowe (.env.local)
 
 ```env
-# Supabase
 VITE_SUPABASE_URL=https://YOUR_PROJECT.supabase.co
 VITE_SUPABASE_ANON_KEY=your_anon_key
-VITE_GOOGLE_CLIENT_ID=your_google_client_id.apps.googleusercontent.com
 
-# Optional: fallback dla development (używane tylko jeśli profil nie ma household_id)
+# Fallback dla dev (używany tylko jeśli profil nie ma household_id)
 VITE_HOUSEHOLD_ID=your_fallback_household_uuid
 ```
 
-### 6. Zastosowanie migracji SQL (Phase 3)
+### 5. Migracje SQL
 
-Otwórz SQL Editor w Supabase Dashboard i uruchom plik:
-`migration/003_authentication_phase3.sql`
+Uruchom w Supabase SQL Editor w kolejności:
 
-Ta migracja:
-- ✅ Tworzy tabelę `profiles` 
-- ✅ Ustawia proper RLS polityki (zabezpiecza dane do household)
-- ✅ Tworzy trigger auto-tworczący profil przy rejestracji
-- ✅ Usuwa permissive polityki z fazy 2
+```
+migration/001_create_budzety.sql
+migration/002_rls_policies_phase2.sql
+migration/003_authentication_phase3.sql
+migration/004_category_embeddings.sql
+migration/005_email_password_auth.sql   ← email+hasło + zachowanie household_id po emailu
+```
 
-### 7. Whitelisting użytkowników (opcjonalnie)
+Migracja 005 podmienia trigger `handle_new_user` tak, żeby przy rejestracji nową metodą zachować `household_id` istniejącego profilu o tym samym emailu (z ery Google).
 
-Jeśli chcesz zezwolić tylko określonym emailom:
+### 6. Dodawanie członka gospodarstwa
 
-1. **Authentication → User Management**
-2. Ręcznie utwórz użytkowników lub
-3. Zapraszaj użytkowników przez URL zaproszenia
-4. W production — ustaw `Email Confirmations` na **ENABLED** aby kontrolować dostęp
-
-## Workflow: Dodawanie nowego członka rodziny
-
-### Scenariusz: Żona chce się zalogować
-
-1. **Admin (inicjalny użytkownik) loguje się** do aplikacji
-2. W Supabase Dashboard:
-   - **Authentication → Users**
-   - **Add User** → wpisz email żony
-   - Wygeneruj hasło tymczasowe
-3. **Żona loguje się za pomocą Google** (używając tego samego emaila)
-4. **Profil żony automatycznie powstaje** (trigger `handle_new_user`)
-5. **Admin przydzielą żonę do household:**
+1. Admin w Supabase Dashboard → **Authentication → Users → Add User**, wpisuje email żony i tymczasowe hasło (albo wysyła invite).
+2. Żona loguje się przez formularz w aplikacji (lub klika invite link i ustawia hasło).
+3. Trigger `handle_new_user` tworzy pusty profil.
+4. Admin przypisuje żonę do household:
    ```sql
    UPDATE public.profiles
-   SET household_id = 'uuid-household'
-   WHERE email = 'zona@example.com';
+      SET household_id = 'uuid-household'
+    WHERE email = 'zona@example.com';
    ```
-6. **Żona będzie widzieć wszystkie dane** z tego household (RLS)
+5. Żona widzi wszystkie dane household (RLS).
+
+## Bezpieczeństwo — dlaczego "Confirm email = ON"
+
+Trigger `handle_new_user` w migracji 005 identyfikuje "stary" profil po emailu i przepina do niego nowy `auth.users.id`, żeby zachować `household_id`. Bez potwierdzenia emaila ktoś obcy mógłby zarejestrować się z cudzym adresem i przejąć cudze finanse. **Confirm email = ON** gwarantuje, że konto powstaje dopiero gdy właściciel adresu kliknie w link potwierdzający.
 
 ## Testowanie
 
-### Test 1: Logowanie przez Google
-- [ ] Klikam przycisk "Zaloguj się przez Google"
-- [ ] Pojawia się popup Google
-- [ ] Po zalogowaniu wracam do aplikacji
-- [ ] Widzę swoje dane (transakcje, budżety, etc.)
+### Test 1: Rejestracja
+- [ ] Na ekranie logowania klikam "Nie masz konta? Zarejestruj się"
+- [ ] Wypełniam email, hasło (≥ 8 znaków), potwierdzenie
+- [ ] Pojawia się komunikat "Sprawdź skrzynkę email…"
+- [ ] Klikam link w emailu → wracam do aplikacji jako zalogowany
 
-### Test 2: Wylogowanie
-- [ ] Klikam przycisk Wyloguj (w profilu)
-- [ ] Sesja czyści się
-- [ ] Powraca mnie na LoginPage
+### Test 2: Logowanie
+- [ ] Wpisuję email + hasło
+- [ ] Zostaję zalogowany, widzę swoje dane
 
-### Test 3: RLS — dostęp do obcych danych
-- [ ] W Supabase SQL Editor, klonem to jako inny użytkownik:
+### Test 3: Reset hasła
+- [ ] Klikam "Zapomniałeś hasła?"
+- [ ] Wpisuję email
+- [ ] Pojawia się komunikat informacyjny
+- [ ] Klikam link w emailu, ustawiam nowe hasło
+
+### Test 4: RLS — dostęp do obcych danych
+- [ ] Po zalogowaniu wykonaj w SQL Editor (jako ten user):
   ```sql
-  SELECT * FROM public.transakcje 
-  WHERE household_id != auth.uid()::uuid;
+  SELECT COUNT(*) FROM public.transakcje
+   WHERE household_id NOT IN (
+     SELECT household_id FROM public.profiles WHERE id = auth.uid()
+   );
   ```
-- [ ] **Powinno zwrócić 0 wierszy** (RLS blokuje dostęp)
-
-### Test 4: Multi-household
-- [ ] Utwórz 2 households (Rodzina A, Rodzina B)
-- [ ] Zaloguj 2 różnych użytkowników z różnych households
-- [ ] Każdy widzi tylko swoje dane
+- [ ] Powinno zwrócić **0** (RLS blokuje dostęp do cudzych household).
 
 ## Troubleshooting
 
 | Problem | Rozwiązanie |
 |---------|-------------|
-| "OAuth credentials error" | Sprawdź Client ID w `.env.local` |
-| Profil nie tworzył się | Sprawdź trigger `handle_new_user` w SQL Editor |
-| RLS: nie widać danych | Sprawdź czy `household_id` jest null w profilu |
-| Google login pusty | Sprawdź redirect URL w Google Cloud Console |
+| "Invalid login credentials" | Zły email/hasło albo email nie został potwierdzony |
+| "Email not confirmed" | Klient nie kliknął linku z emaila — sprawdź skrzynkę, spam |
+| Profil nie utworzony | Sprawdź trigger `handle_new_user` (migracja 005) |
+| Brak widocznych danych | Sprawdź `profiles.household_id` — może być NULL (admin musi przypisać) |
 | 403 Forbidden | Użytkownik nie należy do tego household (RLS) |
-
-## Następne kroki (Phase 4)
-
-- ✅ Phase 3: Autentykacja (DONE)
-- 📋 Phase 4: Optymalizacja
-  - Dodanie offline support z sync
-  - Performance improvements
-  - Error handling
-  - Notification system
 
 ---
 
-**Dokumentacja SQL:**
-- [003_authentication_phase3.sql](../migration/003_authentication_phase3.sql) — migracja RLS i profiles
-- [Supabase RLS Docs](https://supabase.com/docs/guides/auth/row-level-security)
-
-**Czytelna lista komponentów:**
-- [src/contexts/AuthContext.jsx](../src/contexts/AuthContext.jsx) — zarządzanie stanem auth
-- [src/components/LoginPage.jsx](../src/components/LoginPage.jsx) — ekran logowania
-- [src/services/api.js](../src/services/api.js) — API z dynamic household_id
+**Powiązane pliki:**
+- [migration/003_authentication_phase3.sql](../migration/003_authentication_phase3.sql) — RLS + profiles (bez zmian)
+- [migration/005_email_password_auth.sql](../migration/005_email_password_auth.sql) — migracja triggera
+- [src/contexts/AuthContext.jsx](../src/contexts/AuthContext.jsx) — stan auth, signIn/signUp/resetPassword
+- [src/components/LoginPage.jsx](../src/components/LoginPage.jsx) — formularz logowania
+- [src/services/api.js](../src/services/api.js) — API ze wspieraniem RLS
+- [Supabase Auth Docs](https://supabase.com/docs/guides/auth)

--- a/docs/SETUP_SUPABASE.md
+++ b/docs/SETUP_SUPABASE.md
@@ -130,10 +130,9 @@ Po konfiguracji `.env` powinien wyglądać tak:
 VITE_SUPABASE_URL=https://xxxxxxxxxxxxx.supabase.co
 VITE_SUPABASE_ANON_KEY=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...
 VITE_HOUSEHOLD_ID=f47ac10b-58cc-4372-a567-0e02b2c3d479
-
-# Google OAuth (do logowania)
-VITE_GOOGLE_CLIENT_ID=123456789-xxx.apps.googleusercontent.com
 ```
+
+Logowanie działa przez Supabase Auth (email + hasło) — nie wymaga dodatkowych zmiennych w `.env`. Konfiguracja providera odbywa się w Supabase Dashboard (patrz `docs/SETUP_AUTH_PHASE3.md`).
 
 ---
 
@@ -164,7 +163,6 @@ Zawsze używaj HTTPS w produkcji (Vercel/Netlify automatycznie)
    - `VITE_SUPABASE_URL`
    - `VITE_SUPABASE_ANON_KEY`
    - `VITE_HOUSEHOLD_ID`
-   - `VITE_GOOGLE_CLIENT_ID`
 
 2. W Supabase **Project Settings** → **API** → **Authorization** dodaj domenę hostingu do **Allowed origins**:
    ```
@@ -185,8 +183,8 @@ Zawsze używaj HTTPS w produkcji (Vercel/Netlify automatycznie)
 ### "Unauthorized" (401)
 
 - Upewnij się że jesteś zalogowany (przycisk Login)
-- Sprawdź czy `VITE_GOOGLE_CLIENT_ID` jest poprawny
-- Sprawdzunlockedł czy Supabase RLS policies pozwalają na akcję
+- Sprawdź czy Email provider jest włączony w Supabase (Authentication → Providers → Email)
+- Sprawdź czy Supabase RLS policies pozwalają na akcję
 
 ### Migracje nie uruchomiły się
 

--- a/index.html
+++ b/index.html
@@ -14,7 +14,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="description" content="Aplikacja do śledzenia domowego budżetu" />
     <title>Budżet Domowy</title>
-    <script src="https://accounts.google.com/gsi/client" async defer></script>
   </head>
   <body>
     <div id="root"></div>

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -996,7 +996,7 @@ const SettingsPanel = ({ onClose, kategorie, osoby, transakcje, onKategorieChang
 // GŁÓWNA APLIKACJA
 // ============================================
 export default function BudgetApp() {
-  const { user, token, isAuthenticated, isLoading: authLoading, logout } = useAuth();
+  const { user, isAuthenticated, isLoading: authLoading, logout } = useAuth();
   const { addToast } = useToast();
   const { isOffline } = useOffline();
 
@@ -1384,18 +1384,9 @@ export default function BudgetApp() {
 
               {/* User info & logout */}
               <div className="flex items-center gap-1.5 sm:gap-2 bg-white rounded-2xl shadow-sm border border-gray-100 px-2 py-1 sm:px-3 sm:py-1.5">
-                {user?.picture ? (
-                  <img
-                    src={user.picture}
-                    alt={user.name}
-                    className="w-6 h-6 sm:w-7 sm:h-7 rounded-full"
-                    referrerPolicy="no-referrer"
-                  />
-                ) : (
-                  <div className="w-6 h-6 sm:w-7 sm:h-7 rounded-full bg-indigo-100 flex items-center justify-center text-indigo-600">
-                    <Icons.User />
-                  </div>
-                )}
+                <div className="w-6 h-6 sm:w-7 sm:h-7 rounded-full bg-indigo-100 flex items-center justify-center text-indigo-600">
+                  <Icons.User />
+                </div>
                 <span className="text-sm text-gray-600 hidden sm:inline max-w-[120px] truncate" title={user?.email}>
                   {user?.name || user?.email}
                 </span>

--- a/src/components/LoginPage.jsx
+++ b/src/components/LoginPage.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef, useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { useAuth } from '../contexts/AuthContext';
 
 function OfflineBanner() {
@@ -33,26 +33,62 @@ function OfflineBanner() {
   );
 }
 
+const MODES = {
+  SIGNIN: 'signin',
+  SIGNUP: 'signup',
+  RESET: 'reset',
+};
+
 export default function LoginPage() {
-  const { error, setError, clientId, isLoading, isGsiReady, gsiLoadFailed, sessionExpired, retryGsiLoad } = useAuth();
-  const buttonRef = useRef(null);
+  const {
+    isLoading, error, setError, infoMessage, setInfoMessage, sessionExpired,
+    signIn, signUp, resetPassword,
+  } = useAuth();
 
-  useEffect(() => {
-    if (!clientId || !isGsiReady || !buttonRef.current) return;
+  const [mode, setMode] = useState(MODES.SIGNIN);
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [passwordConfirm, setPasswordConfirm] = useState('');
+  const [displayName, setDisplayName] = useState('');
+  const [submitting, setSubmitting] = useState(false);
 
-    if (!window.google?.accounts?.id) return;
+  const switchMode = (newMode) => {
+    setMode(newMode);
+    setError(null);
+    setInfoMessage(null);
+    setPassword('');
+    setPasswordConfirm('');
+  };
 
-    buttonRef.current.replaceChildren();
-    window.google.accounts.id.renderButton(buttonRef.current, {
-      type: 'standard',
-      theme: 'outline',
-      size: 'large',
-      text: 'signin_with',
-      shape: 'pill',
-      logo_alignment: 'left',
-      width: 300,
-    });
-  }, [clientId, isGsiReady]);
+  const validate = () => {
+    if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email)) {
+      setError('Nieprawidłowy adres email.');
+      return false;
+    }
+    if (mode === MODES.RESET) return true;
+    if (password.length < 8) {
+      setError('Hasło musi mieć co najmniej 8 znaków.');
+      return false;
+    }
+    if (mode === MODES.SIGNUP && password !== passwordConfirm) {
+      setError('Hasła nie są identyczne.');
+      return false;
+    }
+    return true;
+  };
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    if (!validate()) return;
+    setSubmitting(true);
+    try {
+      if (mode === MODES.SIGNIN) await signIn(email, password);
+      else if (mode === MODES.SIGNUP) await signUp(email, password, displayName);
+      else if (mode === MODES.RESET) await resetPassword(email);
+    } finally {
+      setSubmitting(false);
+    }
+  };
 
   if (isLoading) {
     return (
@@ -67,11 +103,22 @@ export default function LoginPage() {
     );
   }
 
+  const submitLabel = {
+    [MODES.SIGNIN]: 'Zaloguj się',
+    [MODES.SIGNUP]: 'Zarejestruj się',
+    [MODES.RESET]: 'Wyślij link do resetu',
+  }[mode];
+
+  const title = {
+    [MODES.SIGNIN]: 'Zaloguj się, aby zarządzać finansami',
+    [MODES.SIGNUP]: 'Utwórz konto',
+    [MODES.RESET]: 'Zresetuj hasło',
+  }[mode];
+
   return (
     <div className="min-h-screen bg-gradient-to-br from-gray-50 via-gray-100 to-indigo-50 flex items-center justify-center p-4">
       <div className="w-full max-w-md">
         <div className="rounded-3xl bg-white shadow-2xl p-8 space-y-6">
-          {/* Logo and title */}
           <div className="text-center space-y-4">
             <div className="mx-auto w-16 h-16 rounded-2xl bg-gradient-to-br from-indigo-500 to-purple-600 flex items-center justify-center text-white shadow-lg shadow-indigo-200">
               <svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
@@ -82,14 +129,12 @@ export default function LoginPage() {
             </div>
             <div>
               <h1 className="text-2xl font-bold text-gray-800">Budżet Domowy</h1>
-              <p className="text-gray-500 mt-1">Zaloguj się, aby zarządzać finansami</p>
+              <p className="text-gray-500 mt-1">{title}</p>
             </div>
           </div>
 
-          {/* Offline banner */}
           <OfflineBanner />
 
-          {/* Session expired message */}
           {sessionExpired && !error && (
             <div className="rounded-xl bg-amber-50 border border-amber-200 px-4 py-3 text-sm text-amber-800 flex items-start gap-2">
               <svg className="mt-0.5 shrink-0" xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
@@ -100,7 +145,15 @@ export default function LoginPage() {
             </div>
           )}
 
-          {/* Error message */}
+          {infoMessage && (
+            <div className="rounded-xl bg-emerald-50 border border-emerald-200 px-4 py-3 text-sm text-emerald-700 flex items-start gap-2">
+              <svg className="mt-0.5 shrink-0" xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                <polyline points="20 6 9 17 4 12"></polyline>
+              </svg>
+              <span>{infoMessage}</span>
+            </div>
+          )}
+
           {error && (
             <div className="rounded-xl bg-rose-50 border border-rose-200 px-4 py-3 text-sm text-rose-700 flex items-start gap-2">
               <svg className="mt-0.5 shrink-0" xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
@@ -120,56 +173,99 @@ export default function LoginPage() {
             </div>
           )}
 
-          {/* Login area */}
-          {clientId ? (
-            <div className="flex flex-col items-center gap-4">
-              {gsiLoadFailed ? (
-                /* GIS failed to load */
-                <div className="flex flex-col items-center gap-3 w-full">
-                  <div className="rounded-xl bg-rose-50 border border-rose-200 px-4 py-3 text-sm text-rose-700 text-center w-full">
-                    <p className="font-medium mb-1">Nie można załadować logowania Google</p>
-                    <p className="text-rose-600">Sprawdź połączenie z internetem lub odblokuj google.com w ustawieniach sieci.</p>
-                  </div>
-                  <button
-                    onClick={retryGsiLoad}
-                    className="flex items-center gap-2 px-5 py-2.5 rounded-full border border-gray-300 text-sm text-gray-700 hover:bg-gray-50 hover:border-gray-400 transition-colors"
-                  >
-                    <svg xmlns="http://www.w3.org/2000/svg" width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-                      <polyline points="23 4 23 10 17 10"></polyline>
-                      <path d="M20.49 15a9 9 0 1 1-2.12-9.36L23 10"></path>
-                    </svg>
-                    Spróbuj ponownie
-                  </button>
-                </div>
-              ) : !isGsiReady ? (
-                /* GIS still loading */
-                <div className="flex flex-col items-center gap-2 py-2">
-                  <svg className="animate-spin text-indigo-400" xmlns="http://www.w3.org/2000/svg" width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-                    <path d="M21 12a9 9 0 1 1-6.219-8.56"></path>
-                  </svg>
-                  <span className="text-xs text-gray-400">Ładowanie logowania Google...</span>
-                </div>
-              ) : (
-                /* GIS ready — show button */
-                <div ref={buttonRef} style={{ minHeight: 44 }}></div>
-              )}
+          <form onSubmit={handleSubmit} className="space-y-4">
+            {mode === MODES.SIGNUP && (
+              <div>
+                <label className="block text-sm font-medium text-gray-700 mb-1">
+                  Nazwa użytkownika <span className="text-gray-400 font-normal">(opcjonalnie)</span>
+                </label>
+                <input
+                  type="text"
+                  value={displayName}
+                  onChange={(e) => setDisplayName(e.target.value)}
+                  placeholder="Jan Kowalski"
+                  autoComplete="name"
+                  className="w-full rounded-xl border border-gray-200 px-4 py-2.5 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-400 focus:border-transparent"
+                />
+              </div>
+            )}
 
-              {isGsiReady && !gsiLoadFailed && (
-                <p className="text-xs text-gray-400 text-center">
-                  Logowanie za pomocą konta Google
-                </p>
-              )}
+            <div>
+              <label className="block text-sm font-medium text-gray-700 mb-1">Email</label>
+              <input
+                type="email"
+                value={email}
+                onChange={(e) => setEmail(e.target.value)}
+                placeholder="ty@example.com"
+                autoComplete="email"
+                required
+                className="w-full rounded-xl border border-gray-200 px-4 py-2.5 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-400 focus:border-transparent"
+              />
             </div>
-          ) : (
-            <div className="rounded-xl bg-amber-50 border border-amber-200 px-4 py-3 text-sm text-amber-700">
-              <p className="font-medium mb-1">Brak konfiguracji Google OAuth</p>
-              <p>
-                Ustaw zmienną <code className="bg-amber-100 px-1 rounded">VITE_GOOGLE_CLIENT_ID</code> w pliku <code className="bg-amber-100 px-1 rounded">.env</code>
-              </p>
-            </div>
-          )}
 
-          {/* Footer info */}
+            {mode !== MODES.RESET && (
+              <div>
+                <label className="block text-sm font-medium text-gray-700 mb-1">Hasło</label>
+                <input
+                  type="password"
+                  value={password}
+                  onChange={(e) => setPassword(e.target.value)}
+                  placeholder="Minimum 8 znaków"
+                  autoComplete={mode === MODES.SIGNUP ? 'new-password' : 'current-password'}
+                  required
+                  minLength={8}
+                  className="w-full rounded-xl border border-gray-200 px-4 py-2.5 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-400 focus:border-transparent"
+                />
+              </div>
+            )}
+
+            {mode === MODES.SIGNUP && (
+              <div>
+                <label className="block text-sm font-medium text-gray-700 mb-1">Powtórz hasło</label>
+                <input
+                  type="password"
+                  value={passwordConfirm}
+                  onChange={(e) => setPasswordConfirm(e.target.value)}
+                  autoComplete="new-password"
+                  required
+                  minLength={8}
+                  className="w-full rounded-xl border border-gray-200 px-4 py-2.5 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-400 focus:border-transparent"
+                />
+              </div>
+            )}
+
+            <button
+              type="submit"
+              disabled={submitting}
+              className="w-full rounded-xl bg-gradient-to-r from-indigo-500 to-purple-600 text-white font-medium py-2.5 shadow-lg shadow-indigo-200 hover:shadow-xl hover:shadow-indigo-300 transition-all disabled:opacity-50 disabled:cursor-not-allowed"
+            >
+              {submitting ? 'Przetwarzanie...' : submitLabel}
+            </button>
+          </form>
+
+          <div className="flex items-center justify-between text-xs text-gray-500 pt-2">
+            {mode === MODES.SIGNIN && (
+              <>
+                <button onClick={() => switchMode(MODES.SIGNUP)} className="hover:text-indigo-600 hover:underline">
+                  Nie masz konta? Zarejestruj się
+                </button>
+                <button onClick={() => switchMode(MODES.RESET)} className="hover:text-indigo-600 hover:underline">
+                  Zapomniałeś hasła?
+                </button>
+              </>
+            )}
+            {mode === MODES.SIGNUP && (
+              <button onClick={() => switchMode(MODES.SIGNIN)} className="hover:text-indigo-600 hover:underline">
+                ← Masz już konto? Zaloguj się
+              </button>
+            )}
+            {mode === MODES.RESET && (
+              <button onClick={() => switchMode(MODES.SIGNIN)} className="hover:text-indigo-600 hover:underline">
+                ← Powrót do logowania
+              </button>
+            )}
+          </div>
+
           <div className="border-t border-gray-100 pt-4">
             <p className="text-xs text-gray-400 text-center">
               Dostęp tylko dla autoryzowanych użytkowników.

--- a/src/contexts/AuthContext.jsx
+++ b/src/contexts/AuthContext.jsx
@@ -1,244 +1,125 @@
-import React, { createContext, useContext, useState, useEffect, useCallback, useRef } from 'react';
-import { logger } from '../utils/logger';
+import React, { createContext, useContext, useState, useEffect, useCallback, useMemo } from 'react';
+import { supabase } from '../lib/supabase';
 
 const AuthContext = createContext(null);
 
-const GOOGLE_CLIENT_ID = import.meta.env.VITE_GOOGLE_CLIENT_ID;
-const GIS_TIMEOUT_MS = 10000;
-
-// Decode JWT payload without external libraries.
-// Trust boundary: we do NOT verify the signature here. This is safe because the
-// token is only used client-side for UI state (display name, expiry check). Any
-// server-side call that relies on identity must re-verify the token with Google.
-function decodeJwtPayload(token) {
-  try {
-    const base64Url = token.split('.')[1];
-    const base64 = base64Url.replace(/-/g, '+').replace(/_/g, '/');
-    const jsonPayload = decodeURIComponent(
-      atob(base64)
-        .split('')
-        .map(c => '%' + ('00' + c.charCodeAt(0).toString(16)).slice(-2))
-        .join('')
-    );
-    return JSON.parse(jsonPayload);
-  } catch {
-    return null;
-  }
+function translateAuthError(err) {
+  if (!err) return null;
+  const msg = err.message || '';
+  if (/invalid login credentials/i.test(msg)) return 'Nieprawidłowy email lub hasło.';
+  if (/email not confirmed/i.test(msg)) return 'Email nie został potwierdzony. Sprawdź skrzynkę.';
+  if (/user already registered/i.test(msg)) return 'Użytkownik z tym emailem już istnieje.';
+  if (/password should be at least/i.test(msg)) return 'Hasło musi mieć co najmniej 8 znaków.';
+  if (/rate limit/i.test(msg)) return 'Zbyt wiele prób. Spróbuj ponownie za chwilę.';
+  return msg || 'Wystąpił błąd logowania.';
 }
 
-function isTokenExpired(token) {
-  const payload = decodeJwtPayload(token);
-  if (!payload || !payload.exp) return true;
-  // Add 60s buffer before actual expiration
-  return Date.now() >= (payload.exp - 60) * 1000;
+function normalizeUser(supabaseUser) {
+  if (!supabaseUser) return null;
+  const meta = supabaseUser.user_metadata || {};
+  return {
+    id: supabaseUser.id,
+    email: supabaseUser.email,
+    name: meta.display_name || meta.name || supabaseUser.email,
+  };
 }
 
 export function AuthProvider({ children }) {
-  const [user, setUser] = useState(null);
-  const [token, setToken] = useState(null);
+  const [session, setSession] = useState(null);
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState(null);
-  const [isGsiReady, setIsGsiReady] = useState(false);
-  const [gsiLoadFailed, setGsiLoadFailed] = useState(false);
   const [sessionExpired, setSessionExpired] = useState(false);
-  const gsiInitialized = useRef(false);
+  const [infoMessage, setInfoMessage] = useState(null);
 
-  const handleCredentialResponse = useCallback((response) => {
-    const credential = response.credential;
-    const payload = decodeJwtPayload(credential);
-
-    if (payload) {
-      const userData = {
-        email: payload.email,
-        name: payload.name,
-        picture: payload.picture,
-      };
-      setUser(userData);
-      setToken(credential);
-      setError(null);
-      setSessionExpired(false);
-      localStorage.setItem('budget_auth_token', credential);
-      localStorage.setItem('budget_auth_user', JSON.stringify(userData));
-    } else {
-      setError('Nie udało się zweryfikować danych logowania. Spróbuj ponownie.');
-    }
+  useEffect(() => {
+    supabase.auth.getSession().then(({ data }) => {
+      setSession(data.session);
+      setIsLoading(false);
+    });
+    const { data: sub } = supabase.auth.onAuthStateChange((event, newSession) => {
+      setSession(newSession);
+      if (event === 'SIGNED_IN') {
+        setError(null);
+        setSessionExpired(false);
+      }
+    });
+    return () => sub.subscription.unsubscribe();
   }, []);
 
-  // Shared GIS initialization helper — prevents double-init via gsiInitialized ref.
-  // Returns true if initialization was performed, false if skipped.
-  const doInitGsi = useCallback((autoSelect = false) => {
-    if (!window.google?.accounts?.id || gsiInitialized.current) return false;
-    gsiInitialized.current = true;
-    window.google.accounts.id.initialize({
-      client_id: GOOGLE_CLIENT_ID,
-      callback: handleCredentialResponse,
-      auto_select: autoSelect,
-      cancel_on_tap_outside: false,
-    });
-    setIsGsiReady(true);
+  const signIn = useCallback(async (email, password) => {
+    setError(null);
+    setInfoMessage(null);
+    const { error: err } = await supabase.auth.signInWithPassword({ email, password });
+    if (err) {
+      setError(translateAuthError(err));
+      return false;
+    }
     return true;
-  }, [handleCredentialResponse]);
+  }, []);
 
-  const logout = useCallback((reason = null) => {
-    setUser(null);
-    setToken(null);
-    if (reason === 'expired') {
-      setSessionExpired(true);
+  const signUp = useCallback(async (email, password, displayName) => {
+    setError(null);
+    setInfoMessage(null);
+    const { data, error: err } = await supabase.auth.signUp({
+      email,
+      password,
+      options: {
+        data: { display_name: displayName || email.split('@')[0] },
+        emailRedirectTo: window.location.origin,
+      },
+    });
+    if (err) {
+      setError(translateAuthError(err));
+      return false;
     }
-    localStorage.removeItem('budget_auth_token');
-    localStorage.removeItem('budget_auth_user');
-    // Clear session storage cache as well
+    // Jeśli email confirmation jest włączony, session będzie null — user musi kliknąć link.
+    if (!data.session) {
+      setInfoMessage('Sprawdź swoją skrzynkę email, aby potwierdzić rejestrację.');
+    }
+    return true;
+  }, []);
+
+  const resetPassword = useCallback(async (email) => {
+    setError(null);
+    setInfoMessage(null);
+    const { error: err } = await supabase.auth.resetPasswordForEmail(email, {
+      redirectTo: `${window.location.origin}`,
+    });
+    if (err) {
+      setError(translateAuthError(err));
+      return false;
+    }
+    setInfoMessage('Jeśli konto istnieje, wysłaliśmy link do resetu hasła.');
+    return true;
+  }, []);
+
+  const logout = useCallback(async (reason = null) => {
+    if (reason === 'expired') setSessionExpired(true);
+    await supabase.auth.signOut();
     sessionStorage.clear();
-    // Re-initialize GIS so the login button works again
-    if (window.google?.accounts?.id) {
-      window.google.accounts.id.disableAutoSelect();
-      if (GOOGLE_CLIENT_ID) {
-        // Reset the guard so doInitGsi will proceed
-        gsiInitialized.current = false;
-        doInitGsi(false);
-      }
-    }
-  }, [doInitGsi]);
+  }, []);
 
-  // Listen for session-expired events from API layer
   useEffect(() => {
-    const handleSessionExpired = () => logout('expired');
-    window.addEventListener('auth:session-expired', handleSessionExpired);
-    return () => window.removeEventListener('auth:session-expired', handleSessionExpired);
+    const handler = () => logout('expired');
+    window.addEventListener('auth:session-expired', handler);
+    return () => window.removeEventListener('auth:session-expired', handler);
   }, [logout]);
 
-  // Initialize: check for stored token
-  useEffect(() => {
-    const storedToken = localStorage.getItem('budget_auth_token');
-    const storedUser = localStorage.getItem('budget_auth_user');
-
-    if (storedToken && storedUser) {
-      if (!isTokenExpired(storedToken)) {
-        try {
-          const parsed = JSON.parse(storedUser);
-          if (parsed && typeof parsed === 'object' && typeof parsed.email === 'string') {
-            setToken(storedToken);
-            setUser(parsed);
-          } else {
-            throw new Error('Nieprawidłowa struktura danych użytkownika');
-          }
-        } catch {
-          localStorage.removeItem('budget_auth_token');
-          localStorage.removeItem('budget_auth_user');
-        }
-      } else {
-        // Token expired — show friendly message
-        localStorage.removeItem('budget_auth_token');
-        localStorage.removeItem('budget_auth_user');
-        setSessionExpired(true);
-      }
-    }
-
-    setIsLoading(false);
-  }, []);
-
-  // Initialize Google Identity Services
-  useEffect(() => {
-    if (!GOOGLE_CLIENT_ID) return;
-
-    const tryInit = () => {
-      // Only auto-select / trigger One Tap for users with a valid (non-expired) stored token.
-      // By this point the token-check effect has already cleared any expired token from
-      // localStorage, so checking for expiry here is a belt-and-suspenders safety measure.
-      const storedToken = localStorage.getItem('budget_auth_token');
-      const hasValidToken = !!storedToken && !isTokenExpired(storedToken);
-
-      if (!doInitGsi(hasValidToken)) return;
-
-      // Prompt One Tap for returning users with a valid token
-      if (hasValidToken) {
-        window.google.accounts.id.prompt((notification) => {
-          if (notification.isNotDisplayed() || notification.isSkippedMoment()) {
-            logger.debug(
-              'Auth',
-              'One Tap not shown:',
-              notification.getNotDisplayedReason?.() || notification.getSkippedReason?.()
-            );
-          }
-        });
-      }
-    };
-
-    if (window.google?.accounts?.id) {
-      tryInit();
-    } else {
-      const interval = setInterval(() => {
-        if (window.google?.accounts?.id) {
-          clearInterval(interval);
-          clearTimeout(timeout);
-          tryInit();
-        }
-      }, 100);
-
-      const timeout = setTimeout(() => {
-        clearInterval(interval);
-        // setIsLoading(false) is already called unconditionally by the token-check effect
-        if (!gsiInitialized.current) {
-          setGsiLoadFailed(true);
-        }
-      }, GIS_TIMEOUT_MS);
-
-      return () => {
-        clearInterval(interval);
-        clearTimeout(timeout);
-      };
-    }
-  }, [doInitGsi]);
-
-  // Retry GIS initialization (after network error)
-  const retryGsiLoad = useCallback(() => {
-    setGsiLoadFailed(false);
-    gsiInitialized.current = false;
-
-    if (window.google?.accounts?.id) {
-      doInitGsi(false);
-    } else {
-      // Reload the GIS script dynamically.
-      // gsiInitialized.current is already false (reset above); doInitGsi will set it
-      // back to true once the script loads and window.google.accounts.id is available.
-      const existing = document.querySelector('script[src*="accounts.google.com/gsi"]');
-      if (existing) existing.remove();
-
-      const script = document.createElement('script');
-      script.src = 'https://accounts.google.com/gsi/client';
-      script.async = true;
-      script.defer = true;
-      script.onload = () => {
-        const interval = setInterval(() => {
-          if (window.google?.accounts?.id) {
-            clearInterval(interval);
-            doInitGsi(false);
-          }
-        }, 100);
-        setTimeout(() => {
-          clearInterval(interval);
-          if (!gsiInitialized.current) setGsiLoadFailed(true);
-        }, GIS_TIMEOUT_MS);
-      };
-      script.onerror = () => setGsiLoadFailed(true);
-      document.head.appendChild(script);
-    }
-  }, [doInitGsi]);
+  const user = useMemo(() => normalizeUser(session?.user), [session]);
 
   const value = {
     user,
-    token,
+    isAuthenticated: !!session,
     isLoading,
     error,
     setError,
-    logout,
-    isAuthenticated: !!user && !!token && !isTokenExpired(token),
-    clientId: GOOGLE_CLIENT_ID,
-    handleCredentialResponse,
-    isGsiReady,
-    gsiLoadFailed,
+    infoMessage,
+    setInfoMessage,
     sessionExpired,
-    retryGsiLoad,
+    signIn,
+    signUp,
+    resetPassword,
+    logout,
   };
 
   return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;

--- a/src/test/mocks/supabase.js
+++ b/src/test/mocks/supabase.js
@@ -17,9 +17,14 @@ const mockChain = {
 export const supabase = {
   from: vi.fn(() => mockChain),
   auth: {
-    getSession: vi.fn(),
-    onAuthStateChange: vi.fn(() => ({ 
-      data: { subscription: { unsubscribe: vi.fn() } } 
+    getSession: vi.fn().mockResolvedValue({ data: { session: null }, error: null }),
+    getUser: vi.fn().mockResolvedValue({ data: { user: null }, error: null }),
+    signInWithPassword: vi.fn().mockResolvedValue({ data: { session: null, user: null }, error: null }),
+    signUp: vi.fn().mockResolvedValue({ data: { session: null, user: null }, error: null }),
+    signOut: vi.fn().mockResolvedValue({ error: null }),
+    resetPasswordForEmail: vi.fn().mockResolvedValue({ data: {}, error: null }),
+    onAuthStateChange: vi.fn(() => ({
+      data: { subscription: { unsubscribe: vi.fn() } }
     })),
   },
 };


### PR DESCRIPTION
## Summary

Przejście z hybrydowego logowania (Google Identity Services JWT + Supabase PostgreSQL) na **natywny Supabase Auth z email+hasłem**.

### Motywacja

Stara implementacja miała krytyczną lukę bezpieczeństwa: token JWT od Google był dekodowany tylko po stronie klienta i **nigdy nie trafiał do Supabase**, więc polityki RLS oparte na `auth.uid()` nie miały ważnej sesji — zabezpieczenia były iluzoryczne. Nowa wersja ustanawia realną sesję Supabase Auth, dzięki czemu RLS faktycznie działa.

### Zmiany

**Backend (SQL):**
- `migration/005_email_password_auth.sql` — trigger `handle_new_user` rozpoznaje istniejący profil po emailu (era Google) i przepina `household_id` na nowy `auth.users.id`, zachowując historię transakcji.

**Frontend:**
- `src/contexts/AuthContext.jsx` — pełny rewrite: `signInWithPassword`, `signUp`, `resetPasswordForEmail`, `onAuthStateChange`. Usunięte: GIS, ręczne dekodowanie JWT, localStorage tokenu, `isTokenExpired`, `retryGsiLoad`. Redukcja z ~250 LOC do ~120 LOC.
- `src/components/LoginPage.jsx` — nowy formularz z trybami *signin / signup / reset*, walidacja emaila, hasło ≥ 8 znaków, komunikaty po polsku.
- `index.html` — usunięcie `<script src="accounts.google.com/gsi/client">`.
- `src/App.jsx` — usunięcie nieużywanego `token` i martwej gałęzi `user?.picture`.

**Sprzątanie:**
- `.env.example`, `README.md`, `docs/SETUP_AUTH_PHASE3.md`, `docs/SETUP_SUPABASE.md` — usunięcie `VITE_GOOGLE_CLIENT_ID`, aktualizacja instrukcji setupu.
- `src/test/mocks/supabase.js` — dodane mocki `getUser/signInWithPassword/signUp/signOut/resetPasswordForEmail`.

### Wymagana konfiguracja w Supabase Dashboard (po mergu)

1. **Authentication → Providers → Email:** *Enable email signup: ON*, **Confirm email: ON** (wymagane — chroni przed przejęciem cudzego `household_id` przy rejestracji obcym emailem).
2. **Authentication → Providers → Google:** OFF.
3. (Opcjonalnie) Email Templates — tłumaczenie "Confirm signup" i "Reset password" na PL.
4. Uruchomić `migration/005_email_password_auth.sql` w SQL Editor.

## Test plan

- [ ] Migracja SQL 005 wykonana w Supabase (potwierdzone — trigger `on_auth_user_created` aktywny)
- [ ] Email provider włączony, Google OFF, *Confirm email: ON*
- [x] Testy jednostkowe: 244/244 passed
- [x] `vite build` bez błędów
- [ ] Rejestracja nowym emailem → odebranie linku potwierdzającego → zalogowanie
- [ ] Logowanie istniejącym (potwierdzonym) użytkownikiem
- [ ] Walidacja: błędny email / hasło < 8 znaków / niezgodność powtórzenia hasła
- [ ] Reset hasła: wysłanie linku, ustawienie nowego, zalogowanie
- [ ] RLS: zapytanie `SELECT * FROM transakcje WHERE household_id NOT IN (SELECT household_id FROM profiles WHERE id = auth.uid())` zwraca 0 wierszy
- [ ] Istniejący user z ery Google loguje się tym samym emailem → widzi zachowany `household_id` i historię transakcji
- [ ] Wylogowanie → powrót na LoginPage