### PR TITLE
fix(auth): obsluga linku resetu hasla - formularz nowego hasla

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -996,7 +996,7 @@ const SettingsPanel = ({ onClose, kategorie, osoby, transakcje, onKategorieChang
 // GŁÓWNA APLIKACJA
 // ============================================
 export default function BudgetApp() {
-  const { user, isAuthenticated, isLoading: authLoading, logout } = useAuth();
+  const { user, isAuthenticated, isLoading: authLoading, isRecoveringPassword, logout } = useAuth();
   const { addToast } = useToast();
   const { isOffline } = useOffline();
 
@@ -1035,10 +1035,10 @@ export default function BudgetApp() {
   const { budgets, refresh: refreshBudgets } = useBudgets({
     month: currentPeriod.month,
     year: currentPeriod.year,
-    enabled: isAuthenticated && !isOffline,
+    enabled: isAuthenticated && !isRecoveringPassword && !isOffline,
   });
 
-  const availableYears = useAvailableYears({ enabled: isAuthenticated && !isOffline });
+  const availableYears = useAvailableYears({ enabled: isAuthenticated && !isRecoveringPassword && !isOffline });
 
   // Auto-stop pulse animation after 5 seconds
   // Handle yearly view toggle
@@ -1295,7 +1295,7 @@ export default function BudgetApp() {
     );
   }
 
-  if (!isAuthenticated) {
+  if (!isAuthenticated || isRecoveringPassword) {
     return <LoginPage />;
   }
 

--- a/src/components/LoginPage.jsx
+++ b/src/components/LoginPage.jsx
@@ -37,20 +37,30 @@ const MODES = {
   SIGNIN: 'signin',
   SIGNUP: 'signup',
   RESET: 'reset',
+  NEW_PASSWORD: 'new_password',
 };
 
 export default function LoginPage() {
   const {
     isLoading, error, setError, infoMessage, setInfoMessage, sessionExpired,
-    signIn, signUp, resetPassword,
+    isRecoveringPassword,
+    signIn, signUp, resetPassword, updatePassword, cancelPasswordRecovery,
   } = useAuth();
 
-  const [mode, setMode] = useState(MODES.SIGNIN);
+  const [mode, setMode] = useState(isRecoveringPassword ? MODES.NEW_PASSWORD : MODES.SIGNIN);
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
   const [passwordConfirm, setPasswordConfirm] = useState('');
   const [displayName, setDisplayName] = useState('');
   const [submitting, setSubmitting] = useState(false);
+
+  useEffect(() => {
+    if (isRecoveringPassword) {
+      setMode(MODES.NEW_PASSWORD);
+      setPassword('');
+      setPasswordConfirm('');
+    }
+  }, [isRecoveringPassword]);
 
   const switchMode = (newMode) => {
     setMode(newMode);
@@ -61,6 +71,17 @@ export default function LoginPage() {
   };
 
   const validate = () => {
+    if (mode === MODES.NEW_PASSWORD) {
+      if (password.length < 8) {
+        setError('Hasło musi mieć co najmniej 8 znaków.');
+        return false;
+      }
+      if (password !== passwordConfirm) {
+        setError('Hasła nie są identyczne.');
+        return false;
+      }
+      return true;
+    }
     if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email)) {
       setError('Nieprawidłowy adres email.');
       return false;
@@ -85,6 +106,7 @@ export default function LoginPage() {
       if (mode === MODES.SIGNIN) await signIn(email, password);
       else if (mode === MODES.SIGNUP) await signUp(email, password, displayName);
       else if (mode === MODES.RESET) await resetPassword(email);
+      else if (mode === MODES.NEW_PASSWORD) await updatePassword(password);
     } finally {
       setSubmitting(false);
     }
@@ -107,12 +129,14 @@ export default function LoginPage() {
     [MODES.SIGNIN]: 'Zaloguj się',
     [MODES.SIGNUP]: 'Zarejestruj się',
     [MODES.RESET]: 'Wyślij link do resetu',
+    [MODES.NEW_PASSWORD]: 'Ustaw nowe hasło',
   }[mode];
 
   const title = {
     [MODES.SIGNIN]: 'Zaloguj się, aby zarządzać finansami',
     [MODES.SIGNUP]: 'Utwórz konto',
     [MODES.RESET]: 'Zresetuj hasło',
+    [MODES.NEW_PASSWORD]: 'Ustaw nowe hasło',
   }[mode];
 
   return (
@@ -190,28 +214,32 @@ export default function LoginPage() {
               </div>
             )}
 
-            <div>
-              <label className="block text-sm font-medium text-gray-700 mb-1">Email</label>
-              <input
-                type="email"
-                value={email}
-                onChange={(e) => setEmail(e.target.value)}
-                placeholder="ty@example.com"
-                autoComplete="email"
-                required
-                className="w-full rounded-xl border border-gray-200 px-4 py-2.5 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-400 focus:border-transparent"
-              />
-            </div>
+            {mode !== MODES.NEW_PASSWORD && (
+              <div>
+                <label className="block text-sm font-medium text-gray-700 mb-1">Email</label>
+                <input
+                  type="email"
+                  value={email}
+                  onChange={(e) => setEmail(e.target.value)}
+                  placeholder="ty@example.com"
+                  autoComplete="email"
+                  required
+                  className="w-full rounded-xl border border-gray-200 px-4 py-2.5 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-400 focus:border-transparent"
+                />
+              </div>
+            )}
 
             {mode !== MODES.RESET && (
               <div>
-                <label className="block text-sm font-medium text-gray-700 mb-1">Hasło</label>
+                <label className="block text-sm font-medium text-gray-700 mb-1">
+                  {mode === MODES.NEW_PASSWORD ? 'Nowe hasło' : 'Hasło'}
+                </label>
                 <input
                   type="password"
                   value={password}
                   onChange={(e) => setPassword(e.target.value)}
                   placeholder="Minimum 8 znaków"
-                  autoComplete={mode === MODES.SIGNUP ? 'new-password' : 'current-password'}
+                  autoComplete={mode === MODES.SIGNIN ? 'current-password' : 'new-password'}
                   required
                   minLength={8}
                   className="w-full rounded-xl border border-gray-200 px-4 py-2.5 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-400 focus:border-transparent"
@@ -219,7 +247,7 @@ export default function LoginPage() {
               </div>
             )}
 
-            {mode === MODES.SIGNUP && (
+            {(mode === MODES.SIGNUP || mode === MODES.NEW_PASSWORD) && (
               <div>
                 <label className="block text-sm font-medium text-gray-700 mb-1">Powtórz hasło</label>
                 <input
@@ -262,6 +290,11 @@ export default function LoginPage() {
             {mode === MODES.RESET && (
               <button onClick={() => switchMode(MODES.SIGNIN)} className="hover:text-indigo-600 hover:underline">
                 ← Powrót do logowania
+              </button>
+            )}
+            {mode === MODES.NEW_PASSWORD && (
+              <button onClick={cancelPasswordRecovery} className="hover:text-indigo-600 hover:underline">
+                Anuluj
               </button>
             )}
           </div>

--- a/src/contexts/AuthContext.jsx
+++ b/src/contexts/AuthContext.jsx
@@ -30,15 +30,27 @@ export function AuthProvider({ children }) {
   const [error, setError] = useState(null);
   const [sessionExpired, setSessionExpired] = useState(false);
   const [infoMessage, setInfoMessage] = useState(null);
+  const [isRecoveringPassword, setIsRecoveringPassword] = useState(false);
 
   useEffect(() => {
+    // Supabase puts the recovery token in the URL hash; detect it before the
+    // initial getSession() so we can gate the UI on a "set new password" form
+    // instead of dropping the user straight into the app.
+    if (typeof window !== 'undefined' && window.location.hash.includes('type=recovery')) {
+      setIsRecoveringPassword(true);
+    }
+
     supabase.auth.getSession().then(({ data }) => {
       setSession(data.session);
       setIsLoading(false);
     });
     const { data: sub } = supabase.auth.onAuthStateChange((event, newSession) => {
       setSession(newSession);
-      if (event === 'SIGNED_IN') {
+      if (event === 'PASSWORD_RECOVERY') {
+        setIsRecoveringPassword(true);
+        setError(null);
+        setSessionExpired(false);
+      } else if (event === 'SIGNED_IN') {
         setError(null);
         setSessionExpired(false);
       }
@@ -93,6 +105,32 @@ export function AuthProvider({ children }) {
     return true;
   }, []);
 
+  const updatePassword = useCallback(async (newPassword) => {
+    setError(null);
+    setInfoMessage(null);
+    const { error: err } = await supabase.auth.updateUser({ password: newPassword });
+    if (err) {
+      setError(translateAuthError(err));
+      return false;
+    }
+    setIsRecoveringPassword(false);
+    if (typeof window !== 'undefined' && window.location.hash) {
+      window.history.replaceState(null, '', window.location.pathname + window.location.search);
+    }
+    setInfoMessage('Hasło zostało zmienione.');
+    return true;
+  }, []);
+
+  const cancelPasswordRecovery = useCallback(async () => {
+    setIsRecoveringPassword(false);
+    setError(null);
+    setInfoMessage(null);
+    if (typeof window !== 'undefined' && window.location.hash) {
+      window.history.replaceState(null, '', window.location.pathname + window.location.search);
+    }
+    await supabase.auth.signOut();
+  }, []);
+
   const logout = useCallback(async (reason = null) => {
     if (reason === 'expired') setSessionExpired(true);
     await supabase.auth.signOut();
@@ -116,9 +154,12 @@ export function AuthProvider({ children }) {
     infoMessage,
     setInfoMessage,
     sessionExpired,
+    isRecoveringPassword,
     signIn,
     signUp,
     resetPassword,
+    updatePassword,
+    cancelPasswordRecovery,
     logout,
   };
 


### PR DESCRIPTION
Po klikieciu "Zapomniales hasla?" Supabase odsylal uzytkownika z
tokenem recovery, ale aplikacja od razu logowala go do srodka bez
mozliwosci ustawienia nowego hasla.

- AuthContext nasluchuje zdarzenia PASSWORD_RECOVERY i wykrywa
  fragment URL #type=recovery, ustawiajac flage isRecoveringPassword
- Dodane funkcje updatePassword() i cancelPasswordRecovery()
- LoginPage ma nowy tryb NEW_PASSWORD z polem "nowe haslo" i
  potwierdzeniem
- App.jsx pokazuje LoginPage rowniez gdy isRecoveringPassword=true,
  blokujac fetch danych podczas recovery