### PR TITLE
fix(nav): stabilny układ nawigacji przy przełączaniu Miesiąc/Rok

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1283,6 +1283,14 @@ export default function BudgetApp() {
     );
   }, [sortedTransakcje, searchQuery]);
 
+  // Stan nawigacji okresu — wspólny dla widoku miesięcznego i rocznego
+  const isCurrentMonth =
+    currentPeriod.month === getCurrentMonth().month &&
+    currentPeriod.year === getCurrentMonth().year;
+  const currentYear = new Date().getFullYear();
+  const minYear = Math.min(...availableYears);
+  const maxYear = Math.max(...availableYears);
+
   const groupedByDay = useMemo(() => {
     const groups = [];
     let current = null;
@@ -1422,6 +1430,10 @@ export default function BudgetApp() {
               </button>
             </div>
 
+            {/* Nawigacja okresu — identyczna struktura w obu widokach
+                (‹ | etykieta | › | Dziś), żeby przełączanie Miesiąc/Rok
+                nie przesuwało układu. „Dziś" na bieżącym okresie jest
+                niewidoczny, ale zajmuje miejsce. */}
             {activeView === 'monthly' ? (
               <div className="flex items-center gap-1 sm:gap-2 bg-white rounded-2xl shadow-sm border border-gray-100 p-1">
                 <button
@@ -1441,34 +1453,49 @@ export default function BudgetApp() {
                 >
                   <Icons.ChevronRight />
                 </button>
-                {/* Szybki powrót do bieżącego miesiąca */}
-                {(currentPeriod.month !== getCurrentMonth().month || currentPeriod.year !== getCurrentMonth().year) && (
-                  <button
-                    onClick={() => {
-                      setCurrentPeriod(getCurrentMonth());
-                      setSearchQuery('');
-                    }}
-                    className="rounded-xl px-3 py-1.5 text-sm font-medium text-indigo-600 hover:bg-indigo-50 transition-colors"
-                  >
-                    Dziś
-                  </button>
-                )}
+                <button
+                  onClick={() => {
+                    setCurrentPeriod(getCurrentMonth());
+                    setSearchQuery('');
+                  }}
+                  disabled={isCurrentMonth}
+                  tabIndex={isCurrentMonth ? -1 : 0}
+                  aria-hidden={isCurrentMonth}
+                  className={`rounded-xl px-3 py-1.5 text-sm font-medium text-indigo-600 hover:bg-indigo-50 transition-colors ${isCurrentMonth ? 'invisible' : ''}`}
+                >
+                  Dziś
+                </button>
               </div>
             ) : (
-              <div className="flex items-center gap-1 bg-white rounded-2xl shadow-sm border border-gray-100 p-1 flex-wrap justify-center">
-                {availableYears.map(y => (
-                  <button
-                    key={y}
-                    onClick={() => setSelectedYear(y)}
-                    className={`rounded-xl px-3 py-1.5 text-sm font-medium transition-all ${
-                      selectedYear === y
-                        ? 'bg-indigo-500 text-white shadow-sm'
-                        : 'text-gray-600 hover:bg-gray-100'
-                    }`}
-                  >
-                    {y}
-                  </button>
-                ))}
+              <div className="flex items-center gap-1 sm:gap-2 bg-white rounded-2xl shadow-sm border border-gray-100 p-1">
+                <button
+                  onClick={() => setSelectedYear(y => Math.max(minYear, y - 1))}
+                  disabled={selectedYear <= minYear}
+                  aria-label="Poprzedni rok"
+                  className="rounded-xl p-2.5 text-gray-600 hover:bg-gray-100 transition-colors disabled:opacity-30 disabled:cursor-not-allowed disabled:hover:bg-transparent"
+                >
+                  <Icons.ChevronLeft />
+                </button>
+                <span className="px-2 sm:px-3 py-1 text-sm font-medium text-gray-700 min-w-[130px] sm:min-w-[140px] text-center" aria-live="polite">
+                  {selectedYear}
+                </span>
+                <button
+                  onClick={() => setSelectedYear(y => Math.min(maxYear, y + 1))}
+                  disabled={selectedYear >= maxYear}
+                  aria-label="Następny rok"
+                  className="rounded-xl p-2.5 text-gray-600 hover:bg-gray-100 transition-colors disabled:opacity-30 disabled:cursor-not-allowed disabled:hover:bg-transparent"
+                >
+                  <Icons.ChevronRight />
+                </button>
+                <button
+                  onClick={() => setSelectedYear(currentYear)}
+                  disabled={selectedYear === currentYear}
+                  tabIndex={selectedYear === currentYear ? -1 : 0}
+                  aria-hidden={selectedYear === currentYear}
+                  className={`rounded-xl px-3 py-1.5 text-sm font-medium text-indigo-600 hover:bg-indigo-50 transition-colors ${selectedYear === currentYear ? 'invisible' : ''}`}
+                >
+                  Dziś
+                </button>
               </div>
             )}
           </div>


### PR DESCRIPTION
Widok roczny używał pigułek lat o zmiennej szerokości, więc przełączenie z widoku miesięcznego przesuwało wyśrodkowane elementy nawigacji. Rok ma teraz identyczny nawigator strzałkowy jak miesiąc (‹ | etykieta | › | Dziś, ta sama szerokość etykiety), ze strzałkami ograniczonymi do zakresu dostępnych lat. Przycisk Dziś jest w obu widokach renderowany zawsze, a na bieżącym okresie ukrywany bez zwalniania miejsca (invisible + disabled), żeby jego pojawianie się też nie przesuwało układu.


Claude-Session: https://claude.ai/code/session_018AvPjA3bBiZPz9fvCZMLg5