### PR TITLE
Add transaction type filtering to categorization rules

### DIFF
--- a/components/CSVImport.jsx
+++ b/components/CSVImport.jsx
@@ -65,14 +65,19 @@ const categoryMapping = {
   'prezent': { kategoria: 'Inne', podkategoria: 'Prezenty' },
 };
 
-export const categorizeDescription = (description, userRules = []) => {
+export const categorizeDescription = (description, userRules = [], typ = 'Wydatek') => {
   if (!description) return null;
   const lowerDesc = description.toLowerCase();
   for (const rule of userRules) {
+    // Reguły sprzed wprowadzenia pola typ (bez rule.typ) stosujemy do obu typów.
+    if (rule.typ && rule.typ !== typ) continue;
     if (lowerDesc.includes(rule.keyword.toLowerCase())) {
       return { kategoria: rule.kategoria, podkategoria: rule.podkategoria };
     }
   }
+  // Wbudowany słownik zawiera wyłącznie kategorie wydatkowe — nie stosujemy go
+  // do przychodów (np. zwrot „ZWROT ZAKUP BIEDRONKA" to nie wydatek Jedzenie).
+  if (typ !== 'Wydatek') return null;
   for (const [keyword, category] of Object.entries(categoryMapping)) {
     if (lowerDesc.includes(keyword)) return category;
   }
@@ -630,7 +635,7 @@ export default function CSVImport({ onClose, kategorie = {}, osoby = [], onSaved
           typ = kwotaNum < 0 ? 'Wydatek' : 'Przychód';
         }
 
-        const categoryData = categorizeDescription(opis, recognitionRules);
+        const categoryData = categorizeDescription(opis, recognitionRules, typ);
         const rawKategoria = categoryData?.kategoria || 'Inne';
         const rawPodkategoria = categoryData?.podkategoria || 'Nieprzewidziane';
         const validated = validateCategoryExists(rawKategoria, rawPodkategoria, kategorie, typ);
@@ -681,6 +686,7 @@ export default function CSVImport({ onClose, kategorie = {}, osoby = [], onSaved
     let matchCount = 0;
     const updated = currentTransactions.map(tx => {
       if (tx.kategoria !== 'Inne' || tx.podkategoria !== 'Nieprzewidziane') return tx;
+      if (rule.typ && tx.typ !== rule.typ) return tx;
       if ((tx.opis || '').toLowerCase().includes(keyword)) {
         matchCount++;
         return { ...tx, kategoria: rule.kategoria, podkategoria: rule.podkategoria || '' };
@@ -691,11 +697,11 @@ export default function CSVImport({ onClose, kategorie = {}, osoby = [], onSaved
   }, []);
 
   const handleAddRule = async () => {
-    const { keyword, kategoria, podkategoria } = ruleForm;
+    const { keyword, kategoria, podkategoria, typ } = ruleForm;
     if (!keyword.trim()) { setError('Podaj warunek (tekst do wyszukania)'); return; }
     if (!kategoria) { setError('Wybierz kategorię'); return; }
 
-    const newRule = { keyword: keyword.trim(), kategoria, podkategoria: podkategoria || '', createdAt: Date.now() };
+    const newRule = { keyword: keyword.trim(), kategoria, podkategoria: podkategoria || '', typ, createdAt: Date.now() };
 
     const updatedRules = [...recognitionRules, newRule];
     setRecognitionRules(updatedRules);
@@ -1312,6 +1318,7 @@ export default function CSVImport({ onClose, kategorie = {}, osoby = [], onSaved
                             Jeśli zawiera „<strong>{rule.keyword}</strong>" →{' '}
                             <span className="text-indigo-600 font-medium">{rule.kategoria}</span>
                             {rule.podkategoria && <> &gt; <span className="text-indigo-500">{rule.podkategoria}</span></>}
+                            {rule.typ && <span className="text-gray-400 ml-1">({rule.typ})</span>}
                           </span>
                           <button
                             onClick={() => handleDeleteRule(i)}

--- a/components/__tests__/CSVImport.test.js
+++ b/components/__tests__/CSVImport.test.js
@@ -201,6 +201,63 @@ describe('categorizeDescription', () => {
     const result = categorizeDescription('Biedronka zakupy', []);
     expect(result).toEqual({ kategoria: 'Jedzenie', podkategoria: 'Zakupy domowe' });
   });
+
+  describe('rozróżnianie typu transakcji (Wydatek/Przychód)', () => {
+    it('nie stosuje wbudowanego słownika wydatkowego do przychodów', () => {
+      // Zwrot za zakupy kartą (uznanie) nie może dostać kategorii wydatkowej
+      expect(categorizeDescription('ZWROT ZAKUP BIEDRONKA WARSZAWA', [], 'Przychód')).toBeNull();
+      expect(categorizeDescription('Przelew od Jana — za pizzę i kino', [], 'Przychód')).toBeNull();
+    });
+
+    it('stosuje wbudowany słownik dla wydatków (domyślny typ)', () => {
+      expect(categorizeDescription('Płatność BIEDRONKA', [], 'Wydatek')).toEqual(
+        { kategoria: 'Jedzenie', podkategoria: 'Zakupy domowe' }
+      );
+      // Brak argumentu typ = zachowanie jak dla wydatku (kompatybilność wstecz)
+      expect(categorizeDescription('Płatność BIEDRONKA')).toEqual(
+        { kategoria: 'Jedzenie', podkategoria: 'Zakupy domowe' }
+      );
+    });
+
+    it('nie stosuje reguły z typem Wydatek do przychodu', () => {
+      const userRules = [
+        { keyword: 'biedronka', kategoria: 'Jedzenie', podkategoria: 'Zakupy domowe', typ: 'Wydatek' },
+      ];
+      expect(categorizeDescription('ZWROT BIEDRONKA', userRules, 'Przychód')).toBeNull();
+    });
+
+    it('stosuje regułę z typem Przychód do przychodu', () => {
+      const userRules = [
+        { keyword: 'wynagrodzenie', kategoria: 'Pensja', podkategoria: '', typ: 'Przychód' },
+      ];
+      expect(categorizeDescription('WYNAGRODZENIE ZA LIPIEC', userRules, 'Przychód')).toEqual(
+        { kategoria: 'Pensja', podkategoria: '' }
+      );
+      expect(categorizeDescription('WYNAGRODZENIE ZA LIPIEC', userRules, 'Wydatek')).toBeNull();
+    });
+
+    it('reguły bez typu (starsze) stosuje do obu typów', () => {
+      const userRules = [
+        { keyword: 'allegro', kategoria: 'Dom', podkategoria: 'Wyposażenie' },
+      ];
+      expect(categorizeDescription('ALLEGRO zamówienie', userRules, 'Wydatek')).toEqual(
+        { kategoria: 'Dom', podkategoria: 'Wyposażenie' }
+      );
+      expect(categorizeDescription('ALLEGRO zwrot', userRules, 'Przychód')).toEqual(
+        { kategoria: 'Dom', podkategoria: 'Wyposażenie' }
+      );
+    });
+
+    it('pomija regułę o niezgodnym typie i sprawdza kolejne', () => {
+      const userRules = [
+        { keyword: 'biedronka', kategoria: 'Złe', podkategoria: '', typ: 'Przychód' },
+        { keyword: 'biedronka', kategoria: 'Moje Zakupy', podkategoria: 'Tygodniowe', typ: 'Wydatek' },
+      ];
+      expect(categorizeDescription('BIEDRONKA zakupy', userRules, 'Wydatek')).toEqual(
+        { kategoria: 'Moje Zakupy', podkategoria: 'Tygodniowe' }
+      );
+    });
+  });
 });
 
 // ─── validateCategoryExists ───────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
This PR adds support for transaction type (Wydatek/Przychód) filtering in the categorization system. Rules can now be restricted to specific transaction types, and the built-in category dictionary is only applied to expenses, preventing incorrect categorization of income transactions.

## Key Changes
- **Enhanced `categorizeDescription` function**: Added optional `typ` parameter (defaults to 'Wydatek' for backward compatibility) to filter rules by transaction type
  - User-defined rules with a `typ` field are only applied when the transaction type matches
  - Rules without a `typ` field (legacy rules) apply to both transaction types
  - Built-in category dictionary is now only applied to expenses, not income
  
- **Updated rule application logic**: 
  - When applying rules during CSV import, the transaction type is now passed to `categorizeDescription`
  - When applying rules to existing transactions, rules with mismatched types are skipped
  
- **Enhanced rule creation**: The `typ` field is now captured and stored when creating new recognition rules

- **Improved UI**: Rule display now shows the transaction type in parentheses when specified (e.g., "(Wydatek)")

## Implementation Details
- The change maintains backward compatibility: existing rules without a `typ` field continue to work for both transaction types
- The built-in dictionary (categoryMapping) is treated as expense-only, preventing scenarios like "ZWROT ZAKUP BIEDRONKA" (a refund) from being incorrectly categorized as a food expense
- Comprehensive test coverage added to verify type-based filtering behavior across various scenarios

https://claude.ai/code/session_01JRbp6p9a6Wp2GwyMscLy21