### PR TITLE
fix: kategorie znikały z formularza transakcji po zalogowaniu

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1009,6 +1009,10 @@ export default function BudgetApp() {
   } = useMonthlyData({
     month: currentPeriod.month,
     year: currentPeriod.year,
+    // Bez tej bramki fetch odpala się przed zalogowaniem, pada na braku
+    // sesji i nigdy nie jest ponawiany — po zalogowaniu bez przeładowania
+    // strony formularz transakcji zostawał bez kategorii.
+    enabled: isAuthenticated && !isRecoveringPassword,
   });
 
   // Yearly summary view state

--- a/src/hooks/__tests__/useMonthlyData.test.js
+++ b/src/hooks/__tests__/useMonthlyData.test.js
@@ -78,6 +78,28 @@ describe('useMonthlyData', () => {
     expect(api.getAllData).not.toHaveBeenCalled();
   });
 
+  it('pobiera dane po przejściu enabled false -> true (logowanie)', async () => {
+    api.getAllData.mockResolvedValue({
+      transakcje: [],
+      kategorie: { Wydatek: { Jedzenie: ['Lidl'] }, Przychód: {} },
+      osoby: [],
+    });
+
+    const { result, rerender } = renderHook(
+      ({ enabled }) => useMonthlyData({ month: 1, year: 2026, enabled }),
+      { initialProps: { enabled: false } }
+    );
+    expect(api.getAllData).not.toHaveBeenCalled();
+
+    rerender({ enabled: true });
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+    expect(api.getAllData).toHaveBeenCalledTimes(1);
+    expect(result.current.kategorie).toEqual({ Wydatek: { Jedzenie: ['Lidl'] }, Przychód: {} });
+  });
+
   it('odpornie traktuje brak pól w odpowiedzi API', async () => {
     api.getAllData.mockResolvedValue({});
     const { result } = renderHook(() => useMonthlyData({ month: 1, year: 2026 }));
@@ -109,6 +131,32 @@ describe('useMonthlyData', () => {
     expect(api.seedDefaultKategorie).toHaveBeenCalledTimes(1);
     expect(result.current.kategorie).toEqual({
       Wydatek: { Jedzenie: ['Zakupy domowe'] },
+      Przychód: {},
+    });
+  });
+
+  it('ponawia getKategorie gdy słownik pusty mimo seeded=0 (przejściowy błąd)', async () => {
+    // getAllData połknęło błąd getKategorie i zwróciło pusty słownik,
+    // choć gospodarstwo ma kategorie (seed nic nie wstawia).
+    api.getAllData.mockResolvedValue({
+      transakcje: [{ id: '1', kwota: 10 }],
+      kategorie: { Wydatek: {}, Przychód: {} },
+      osoby: [],
+    });
+    api.seedDefaultKategorie.mockResolvedValue({ success: true, seeded: 0 });
+    api.getKategorie.mockResolvedValue({
+      Wydatek: { Jedzenie: ['Lidl'] },
+      Przychód: {},
+    });
+
+    const { result } = renderHook(() => useMonthlyData({ month: 1, year: 2026 }));
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+    expect(api.getKategorie).toHaveBeenCalledTimes(1);
+    expect(result.current.kategorie).toEqual({
+      Wydatek: { Jedzenie: ['Lidl'] },
       Przychód: {},
     });
   });

--- a/src/hooks/useMonthlyData.js
+++ b/src/hooks/useMonthlyData.js
@@ -44,10 +44,11 @@ export function useMonthlyData({ month, year, enabled = true }) {
       if (kategorieEmpty(kategorie) && !seedAttemptedRef.current) {
         seedAttemptedRef.current = true;
         try {
-          const { seeded } = await api.seedDefaultKategorie();
-          if (seeded > 0) {
-            kategorie = await api.getKategorie();
-          }
+          await api.seedDefaultKategorie();
+          // Refetch także gdy nic nie zasiano: pusty słownik może pochodzić
+          // z przejściowego błędu getKategorie połkniętego przez getAllData,
+          // podczas gdy baza ma komplet kategorii.
+          kategorie = await api.getKategorie();
         } catch (seedErr) {
           logger.error('useMonthlyData:seed', seedErr);
         }


### PR DESCRIPTION
## Problem

Po zalogowaniu karta dodania transakcji pokazywała pusty słownik kategorii (tylko „-- Wybierz --", przycisk zapisu zablokowany). Objaw znikał po odświeżeniu strony lub zmianie miesiąca, więc bywał nieregularny.

## Przyczyny

1. **`useMonthlyData` nie było spięte ze stanem logowania** — w odróżnieniu od `useBudgets` i `useAvailableYears`, które dostają `enabled: isAuthenticated`. Pobranie danych odpalało się raz, przy montowaniu aplikacji, jeszcze przed sesją, i padało na „Użytkownik nie zalogowany". Logowanie nie przeładowuje strony, a nic nie ponawiało pobrania — kategorie (i transakcje) zostawały puste, z zawieszonym komunikatem błędu.

2. **`getAllData` po cichu zamienia błąd `getKategorie` na pusty słownik**, a ścieżka auto-zasiewu (#102) ponawiała `getKategorie` tylko przy `seeded > 0`. Gdy gospodarstwo ma już kategorie (seed nic nie wstawia), przejściowy błąd zostawiał pusty słownik do następnego odświeżenia.

## Zmiany

- `src/App.jsx` — `useMonthlyData` dostaje `enabled: isAuthenticated && !isRecoveringPassword`; dane ładują się dopiero po zalogowaniu i ponawiają przy każdym logowaniu.
- `src/hooks/useMonthlyData.js` — po próbie auto-zasiewu słownik kategorii jest pobierany ponownie bezwarunkowo (pokrywa też scenariusz połkniętego błędu przy `seeded === 0`).
- `src/hooks/__tests__/useMonthlyData.test.js` — 2 testy regresyjne: fetch po przejściu `enabled` false → true (logowanie) oraz ponowne pobranie słownika przy `seeded === 0`.

## Weryfikacja

- vitest: 302/302 (300 dotychczasowych + 2 nowe)
- `npm run build` przechodzi
- Migracje 010–012 z #110 sprawdzone — czysto addytywne, nie dotykają istniejących wierszy słownika

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017H1z7PEZxzzLiS3FguZThc

---
_Generated by [Claude Code](https://claude.ai/code/session_017H1z7PEZxzzLiS3FguZThc)_